### PR TITLE
Add support for batch queries

### DIFF
--- a/src/scripting/functions.rs
+++ b/src/scripting/functions.rs
@@ -260,6 +260,16 @@ pub async fn execute_prepared(
 }
 
 #[rune::function(instance)]
+pub async fn batch_prepared(
+    ctx: Ref<Context>,
+    keys: Vec<Ref<str>>,
+    params: Vec<Value>,
+) -> Result<(), CassError> {
+    ctx.batch_prepared(keys.iter().map(|k| k.deref()).collect(), params)
+        .await
+}
+
+#[rune::function(instance)]
 pub async fn init_partition_row_distribution_preset(
     mut ctx: Mut<Context>,
     preset_name: Ref<str>,

--- a/src/scripting/mod.rs
+++ b/src/scripting/mod.rs
@@ -28,6 +28,7 @@ fn try_install(
     context_module.function_meta(functions::execute)?;
     context_module.function_meta(functions::prepare)?;
     context_module.function_meta(functions::execute_prepared)?;
+    context_module.function_meta(functions::batch_prepared)?;
     context_module.function_meta(functions::init_partition_row_distribution_preset)?;
     context_module.function_meta(functions::get_partition_idx)?;
     context_module.function_meta(functions::get_datacenters)?;


### PR DESCRIPTION
Example of it's usage:
```
  pub async fn insert(db, i) {
    ...
    let stmt_keys = [];
    let stmt_values = [];
    ...
    stmt_keys.push(some_prepared_statement_name);
    stmt_values.push([
      user_id, user_name, permissions,
    ]);
    ...
    db.batch_prepared(stmt_keys, stmt_values).await?
    ...
  }
```
To reuse the same gathered values in non-batch call do following:
```
  pub async fn insert(db, i) {
    ...
    db.execute_prepared(stmt_keys[0], stmt_values[0]).await?
    ...
  }
```

Closes: https://github.com/scylladb/latte/issues/12