### PR TITLE
Add support for peer certificate verification

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -173,6 +173,10 @@ pub struct ConnectionConf {
     #[clap(long("ssl-key"), value_name = "PATH")]
     pub ssl_key_file: Option<PathBuf>,
 
+    /// Verify if the peer's certificate is trusted
+    #[clap(long("ssl-peer-verification"))]
+    pub ssl_peer_verification: bool,
+
     /// Datacenter name
     #[clap(long("datacenter"), required = false)]
     pub datacenter: Option<String>,

--- a/src/scripting/connect.rs
+++ b/src/scripting/connect.rs
@@ -1,7 +1,7 @@
 use crate::config::ConnectionConf;
 use crate::scripting::cass_error::{CassError, CassErrorKind};
 use crate::scripting::context::Context;
-use openssl::ssl::{SslContext, SslContextBuilder, SslFiletype, SslMethod};
+use openssl::ssl::{SslContext, SslContextBuilder, SslFiletype, SslMethod, SslVerifyMode};
 use scylla::load_balancing::DefaultPolicy;
 use scylla::transport::session::PoolSize;
 use scylla::{ExecutionProfile, SessionBuilder};
@@ -17,6 +17,9 @@ fn ssl_context(conf: &&ConnectionConf) -> Result<Option<SslContext>, CassError> 
         }
         if let Some(path) = &conf.ssl_key_file {
             ssl.set_private_key_file(path, SslFiletype::PEM)?;
+        }
+        if conf.ssl_peer_verification {
+            ssl.set_verify(SslVerifyMode::PEER);
         }
         Ok(Some(ssl.build()))
     } else {


### PR DESCRIPTION
In Rust driver, when TLS encryption is enabled, there is a possibility to perform verification if the server certificate is trusted.

The change adds support of peer's certificate verification to latte.

Fixes: https://github.com/scylladb/latte/issues/15