### PR TITLE
Add possibility to run stress with sinusoidally changing rate

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -186,7 +186,9 @@ async fn load(conf: LoadCommand) -> Result<()> {
     let load_options = ExecutionOptions {
         duration: config::Interval::Count(load_count),
         cycle_range: (0, i64::MAX),
-        rate: conf.rate,
+        rate: conf.rate.rate,
+        rate_sine_amplitude: conf.rate.rate_sine_amplitude,
+        rate_sine_period: conf.rate.rate_sine_period,
         threads: conf.threads,
         concurrency: conf.concurrency,
     };
@@ -250,6 +252,8 @@ async fn run(conf: RunCommand) -> Result<()> {
             duration: conf.warmup_duration,
             cycle_range: (conf.start_cycle, conf.end_cycle),
             rate: None,
+            rate_sine_amplitude: conf.rate.rate_sine_amplitude,
+            rate_sine_period: conf.rate.rate_sine_period,
             threads: conf.threads,
             concurrency: conf.concurrency,
         };
@@ -278,7 +282,9 @@ async fn run(conf: RunCommand) -> Result<()> {
         duration: conf.run_duration,
         cycle_range: (conf.start_cycle, conf.end_cycle),
         concurrency: conf.concurrency,
-        rate: conf.rate,
+        rate: conf.rate.rate,
+        rate_sine_amplitude: conf.rate.rate_sine_amplitude,
+        rate_sine_period: conf.rate.rate_sine_period,
         threads: conf.threads,
     };
 

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -82,7 +82,7 @@ impl Report {
                 .and_then(|ts| Local.timestamp_opt(ts, 0).latest()),
             tags: self.conf.tags.clone(),
             params: self.conf.params.clone(),
-            rate: self.conf.rate,
+            rate: self.conf.rate.rate,
             throughput: self.result.cycle_throughput.value,
             latency_p50: self
                 .result
@@ -545,7 +545,7 @@ impl<'a> Display for RunConfigCmp<'a> {
             self.line("Concurrency", "req", |conf| {
                 Quantity::from(conf.concurrency)
             }),
-            self.line("Max rate", "op/s", |conf| Quantity::from(conf.rate)),
+            self.line("Max rate", "op/s", |conf| Quantity::from(conf.rate.rate)),
             self.line("Warmup", "s", |conf| {
                 Quantity::from(conf.warmup_duration.period_secs())
             }),


### PR DESCRIPTION
To enable it just define following parameters:
```
  --rate=1000
  --rate-sine-amplitude=0.2 // rate +- 20%
  --rate-sine-period=10s
```

Note that sine wave gets enabled only when the `--rate=%value%` is defined.