### PR TITLE
Make log creation be configurable

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -490,7 +490,7 @@ pub struct RunCommand {
     #[clap(long("tag"), value_delimiter = ',')]
     pub tags: Vec<String>,
 
-    /// Wether to generate final report or not. If disabled (default) then memory consumption will
+    /// Whether to generate final report or not. If disabled (default) then memory consumption will
     /// be static, otherwise it will leak linearly storing samples info for a final report
     /// calculation.
     #[clap(long("generate-report"), required = false)]
@@ -705,6 +705,10 @@ pub struct AppConfig {
     /// Directory where log files are stored.
     #[clap(long("log-dir"), env("LATTE_LOG_DIR"), default_value = ".")]
     pub log_dir: PathBuf,
+
+    /// Whether to create log file and write to it or not.
+    #[clap(long("enable-logging"), required = false)]
+    pub enable_logging: bool,
 
     #[clap(subcommand)]
     pub command: Command,

--- a/src/main.rs
+++ b/src/main.rs
@@ -563,12 +563,16 @@ fn run_id() -> String {
 fn main() {
     let run_id = run_id();
     let config = AppConfig::parse();
-    let _guard = match setup_logging(run_id.as_str(), &config) {
-        Ok(guard) => guard,
-        Err(e) => {
-            eprintln!("error: {e}");
-            exit(1);
+    let _guard = if config.enable_logging {
+        match setup_logging(run_id.as_str(), &config) {
+            Ok(guard) => Some(guard),
+            Err(e) => {
+                eprintln!("error: {e}");
+                exit(1);
+            }
         }
+    } else {
+        None
     };
 
     let command = config.command;


### PR DESCRIPTION
For now each latte usage creates a log file.
And frequent small usages make it generate a lot of garbage log files.
So, make it's creation be configurable and disable it by default.