### PR TITLE
[docs] Use proper installation command for the fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ dpkg -i latte-<version>.deb
 ## From source
 
 1. [Install Rust toolchain](https://rustup.rs/)
-2. Run `cargo install latte-cli`
+2. Run `cargo install --path .`
 
 ## Usage
 


### PR DESCRIPTION
`latte-cli` refers to the original latte, not our fork.
So, update the `install` example command in the `README.md` file
to have the proper command for any repository, not only original.