### PR TITLE
Add possibility to write HDR histogram data to a file in real time

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -496,6 +496,14 @@ pub struct RunCommand {
     #[clap(long("generate-report"), required = false)]
     pub generate_report: bool,
 
+    /// Path to a file for streaming HDR histogram data in real-time.
+    #[clap(
+        long("hdrfile"),
+        aliases = &["hdr-file", "hdr-histogram", "hdr-histogram-file"],
+        required = false
+    )]
+    pub hdrfile: Option<PathBuf>,
+
     /// Path to an output file or directory where the JSON report should be written to.
     #[clap(short('o'), long)]
     #[serde(skip)]

--- a/src/exec/mod.rs
+++ b/src/exec/mod.rs
@@ -19,6 +19,7 @@ use tokio::time::MissedTickBehavior;
 use tokio_stream::wrappers::IntervalStream;
 
 use crate::error::{LatteError, Result};
+use crate::stats::histogram::HistogramWriter;
 use crate::{
     BenchmarkStats, BoundedCycleCounter, Interval, Progress, Recorder, Workload, WorkloadStats,
 };
@@ -304,6 +305,7 @@ pub async fn par_execute(
     workload: Workload,
     show_progress: bool,
     keep_log: bool,
+    hdrh_writer: &mut Option<Box<dyn HistogramWriter>>,
 ) -> Result<BenchmarkStats> {
     if exec_options.cycle_range.1 <= exec_options.cycle_range.0 {
         return Err(LatteError::Configuration(format!(
@@ -329,7 +331,7 @@ pub async fn par_execute(
     let progress = Arc::new(StatusLine::with_options(progress, progress_opts));
     let deadline = BoundedCycleCounter::new(exec_options.duration, exec_options.cycle_range);
     let mut streams = Vec::with_capacity(thread_count);
-    let mut stats = Recorder::start(rate, concurrency, keep_log);
+    let mut stats = Recorder::start(rate, concurrency, keep_log, hdrh_writer);
 
     for _ in 0..thread_count {
         let s = spawn_stream(


### PR DESCRIPTION
Before, it was possible to get HDR histograms data only after
a stress command completion - when report gets generated.
For using latte in performance testing we need to have these data in real time.

So, add such a possibility.
It gets enabled when following new config option is specified:
```
  --hdrfile /path/to/hdrfile
```
If the target file is absent then it will be created automatically.