### PR TITLE
Add support for the `Date`, `Time` and `Varint` CQL data types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ regex = "1.5"
 rune = "0.13"
 rust_decimal = "1.36"
 rust-embed = "8"
-scylla = { version = "1.0", features = ["openssl-010"] }
+scylla = { version = "1.0", features = ["openssl-010", "chrono-04"] }
 search_path = "0.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/src/scripting/cass_error.rs
+++ b/src/scripting/cass_error.rs
@@ -4,7 +4,7 @@ use rune::runtime::{TypeInfo, VmResult};
 use rune::{vm_write, Any};
 use scylla::errors::{ExecutionError, NewSessionError, PrepareError};
 use scylla::response::query_result::IntoRowsResultError;
-use scylla::value::CqlValue;
+use scylla::value::{CqlValue, ValueOverflow};
 use std::fmt::{Display, Formatter};
 
 #[derive(Any, Debug)]
@@ -93,13 +93,13 @@ impl CassError {
                 write!(buf, "QueryRetriesExceeded: {s}")
             }
             CassErrorKind::ValueOutOfRange(v, t) => {
-                write!(buf, "Value {v} out of range for Cassandra type {t:?}")
+                write!(buf, "Value {v} out of range for CQL type {t:?}")
             }
             CassErrorKind::QueryParamConversion(v, t, None) => {
-                write!(buf, "Cannot convert value {v} to Cassandra type {t:?}")
+                write!(buf, "Cannot convert value {v} to CQL type {t:?}")
             }
             CassErrorKind::QueryParamConversion(v, t, Some(e)) => {
-                write!(buf, "Cannot convert value {v} to Cassandra type {t:?}: {e}")
+                write!(buf, "Cannot convert value {v} to CQL type {t:?}: {e}")
             }
             CassErrorKind::InvalidNumberOfQueryParams => {
                 write!(buf, "Incorrect number of query parameters")
@@ -134,6 +134,12 @@ impl Display for CassError {
 impl From<ErrorStack> for CassError {
     fn from(e: ErrorStack) -> CassError {
         CassError(CassErrorKind::SslConfiguration(e))
+    }
+}
+
+impl From<ValueOverflow> for CassError {
+    fn from(e: ValueOverflow) -> CassError {
+        CassError(CassErrorKind::Error(e.to_string()))
     }
 }
 


### PR DESCRIPTION
Example of the `Date` CQL type usage in a rune script:
```
  let date1 = "2024-11-05";
  let date2 = i % (2).pow(31);

  // Following example shows an approach for creating variable date values
  let current_y_part = i % 9;
  let current_m_part = if i % 12 == 0 {1} else {i % 12};
  let current_d_part = if i % 30 == 0 {1} else {i % 30};
  let date3 = `201${current_y_part}-${current_m_part}-${current_d_part}`;
```

Example of the `Time` CQL type usage in a rune script:
```
  let time1 = "1:23:05";
  let time2 = "20:01:54.123456789";
  let time3 = hash(i);
```

Example of the `Varint` CQL type usage in a rune script:
```
  // varint1 has more than 64 chars which is bigger than bigint
  let varint1 = "1234567890123456789012345678901234567890123456789012345678901234567890";
  let varint2 = hash(i);
```