### PR TITLE
Add support for the Tuple CQL data type

### DIFF
--- a/src/scripting/bind.rs
+++ b/src/scripting/bind.rs
@@ -15,7 +15,7 @@ use itertools::*;
 
 fn to_scylla_value(v: &Value, typ: &ColumnType) -> Result<CqlValue, CassError> {
     // TODO: add support for the following CQL data types:
-    //       'duration' and 'tuple'.
+    //       'duration'
     match (v, typ) {
         (Value::Bool(v), ColumnType::Native(NativeType::Boolean)) => Ok(CqlValue::Boolean(*v)),
 
@@ -175,6 +175,24 @@ fn to_scylla_value(v: &Value, typ: &ColumnType) -> Result<CqlValue, CassError> {
             Some(v) => to_scylla_value(v, typ),
             None => Ok(CqlValue::Empty),
         },
+        (Value::Tuple(v), ColumnType::Tuple(tuple)) => {
+            let v = v.borrow_ref().unwrap();
+            let mut elements = Vec::with_capacity(v.len());
+            for (i, current_element) in v.iter().enumerate() {
+                let element = to_scylla_value(current_element, &tuple[i])?;
+                elements.push(Some(element));
+            }
+            Ok(CqlValue::Tuple(elements))
+        }
+        (Value::Vec(v), ColumnType::Tuple(tuple)) => {
+            let v = v.borrow_ref().unwrap();
+            let mut elements = Vec::with_capacity(v.len());
+            for (i, current_element) in v.iter().enumerate() {
+                let element = to_scylla_value(current_element, &tuple[i])?;
+                elements.push(Some(element));
+            }
+            Ok(CqlValue::Tuple(elements))
+        }
         (
             Value::Vec(v),
             ColumnType::Collection {


### PR DESCRIPTION
Example of the `Tuple` CQL type usage in a rune script:
```
  // As rune tuple value
  let tuple1 = (text(i, 10), blob(i, 20));
  // As rune vector value
  let tuple2 = [hash(i), 111];
```