### PR TITLE
Add posibility to validate number of returned rows for read queries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1267,7 +1267,7 @@ dependencies = [
 
 [[package]]
 name = "latte-cli"
-version = "0.28.4-scylladb"
+version = "0.28.5-scylladb"
 dependencies = [
  "anyhow",
  "assert_approx_eq",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "latte-cli"
 description = "A database benchmarking tool for Apache Cassandra and ScyllaDB"
-version = "0.28.4-scylladb"
+version = "0.28.5-scylladb"
 authors = ["Piotr Kołaczkowski <pkolaczk@gmail.com>"]
 edition = "2021"
 readme = "README.md"

--- a/src/config.rs
+++ b/src/config.rs
@@ -220,6 +220,20 @@ pub struct ConnectionConf {
         value_name = "MIN[,MAX]"
     )]
     pub retry_interval: RetryInterval,
+
+    /// Defines the strategy for 'select' queries validation errors.
+    /// Gets applied when 'execute_prepared_with_validation'
+    /// or 'execute_with_validation' context methods are used in rune scripts.
+    #[clap(long("validation-strategy"), required = false, default_value = "retry")]
+    pub validation_strategy: ValidationStrategy,
+}
+
+#[derive(Clone, Copy, Default, Debug, Eq, PartialEq, Serialize, Deserialize, ValueEnum)]
+pub enum ValidationStrategy {
+    #[default]
+    Retry, // Retry 'select' queries if rows number is unexpected.
+    FailFast, // Stop stress execution right after any 'select' query validation fails.
+    Ignore,   // Ignore validation errors - face, print, go on.
 }
 
 #[derive(Clone, Copy, Default, Debug, Eq, PartialEq, Serialize, Deserialize)]

--- a/src/scripting/connect.rs
+++ b/src/scripting/connect.rs
@@ -61,6 +61,7 @@ pub async fn connect(conf: &ConnectionConf) -> Result<Context, CassError> {
         datacenter,
         conf.retry_number,
         conf.retry_interval,
+        conf.validation_strategy,
     ))
 }
 

--- a/src/scripting/mod.rs
+++ b/src/scripting/mod.rs
@@ -25,12 +25,16 @@ fn try_install(
 ) -> Result<(), ContextError> {
     let mut context_module = Module::default();
     context_module.ty::<Context>()?;
-    context_module.function_meta(functions::execute)?;
     context_module.function_meta(functions::prepare)?;
+    context_module.function_meta(functions::execute)?;
+    context_module.function_meta(functions::execute_with_validation)?;
     context_module.function_meta(functions::execute_prepared)?;
+    context_module.function_meta(functions::execute_prepared_with_validation)?;
     context_module.function_meta(functions::batch_prepared)?;
     context_module.function_meta(functions::init_partition_row_distribution_preset)?;
     context_module.function_meta(functions::get_partition_idx)?;
+    context_module.ty::<functions::Partition>()?;
+    context_module.function_meta(functions::get_partition_info)?;
     context_module.function_meta(functions::get_datacenters)?;
     context_module.function_meta(functions::elapsed_secs)?;
 

--- a/workloads/validation.rn
+++ b/workloads/validation.rn
@@ -1,0 +1,153 @@
+// This rune script shows how we can do followig:
+// - Validate the number of returned rows in 'SELECT' queries
+// - Validate that the 'SELECT COUNT(...)' queries return integer equal to the expected rows number
+// - Do above for partitions of any size using 'partitions preset' latte feature
+// - Do above using prepared and non-prepared statements
+//
+// USAGE:
+// 1) Create schema:
+// $ latte schema workloads/validation.rn 172.17.0.2
+//
+// 2) Populate DB:
+// $ latte run workloads/validation.rn -q \
+//     -d 1000 -r 1000 -P row_count=1000 \
+//     -P rows_per_partition=1 -P partition_sizes="\"50:4,50:6\"" \
+//     -f insert -- 172.17.0.2
+//
+// 3) Do select queries with validation
+//
+// 3a) Get one row
+// $ latte run workloads/validation.rn -q \
+//     -d 1000 -r 1000 -P row_count=1000 \
+//     -P rows_per_partition=1 -P partition_sizes="\"50:4,50:6\"" \
+//     -f get -- 172.17.0.2
+//
+// 3b) Get many rows
+// $ latte run workloads/validation.rn -q \
+//     -d 1000 -r 1000 -P row_count=1000 \
+//     -P rows_per_partition=1 -P partition_sizes="\"50:4,50:6\"" \
+//     -f get_many -- 172.17.0.2
+//
+// 3c) Count
+// $ latte run workloads/validation.rn -q \
+//     -d 1000 -r 1000 -P row_count=1000 \
+//     -P rows_per_partition=1 -P partition_sizes="\"50:4,50:6\"" \
+//     -f count -- 172.17.0.2
+
+use latte::*;
+
+const ROW_COUNT = latte::param!("row_count", 1000000);
+const OFFSET = latte::param!("offset", 0);
+const REPLICATION_FACTOR = latte::param!("replication_factor", 3);
+const ROWS_PER_PARTITION = latte::param!("rows_per_partition", 1);
+// NOTE: 'partition_sizes' defines set of 'percent:multiplier' pairs to create multi-row partitions
+// of different sizes. Example: '95:1,4:2,1:4'
+const PARTITION_SIZES = latte::param!("partition_sizes", "100:1");
+
+const USE_PREPARED_STATEMENTS = latte::param!("use_prepared_statements", true);
+
+const KEYSPACE = "latte";
+const TABLE = "validation";
+
+const P_STMT = #{
+    "INSERT": #{
+        "NAME": "p_stmt_validation__insert",
+        "CQL": `INSERT INTO ${KEYSPACE}.${TABLE}(pk, ck) VALUES (:pk, :ck)`,
+    },
+    "GET": #{
+        "NAME": "p_stmt_validation__get",
+        "CQL": `SELECT pk, ck FROM ${KEYSPACE}.${TABLE} WHERE pk = :pk LIMIT 1`,
+    },
+    "GET_MANY": #{
+        "NAME": "p_stmt_validation__get_many",
+        "CQL": `SELECT pk, ck FROM ${KEYSPACE}.${TABLE} WHERE pk = :pk LIMIT :max_limit`,
+    },
+    "COUNT": #{
+        "NAME": "p_stmt_validation__count",
+        "CQL": `SELECT COUNT(*) FROM ${KEYSPACE}.${TABLE} WHERE pk = :pk`,
+    },
+};
+
+pub async fn schema(db) {
+    db.execute(`CREATE KEYSPACE IF NOT EXISTS ${KEYSPACE} WITH REPLICATION = {
+        'class': 'NetworkTopologyStrategy', 'replication_factor': ${REPLICATION_FACTOR} }`).await?;
+
+    db.execute(`CREATE TABLE IF NOT EXISTS ${KEYSPACE}.${TABLE}(
+        pk bigint,
+        ck bigint,
+        PRIMARY KEY (pk, ck)
+    ) WITH CLUSTERING ORDER BY (ck ASC)`).await?;
+}
+
+pub async fn erase(db) {
+    db.execute(`TRUNCATE TABLE ${KEYSPACE}.${TABLE}`).await?
+}
+
+pub async fn prepare(db) {
+    db.init_partition_row_distribution_preset(
+        "main", ROW_COUNT, ROWS_PER_PARTITION, PARTITION_SIZES,
+    ).await?;
+    db.prepare(P_STMT.INSERT.NAME, P_STMT.INSERT.CQL).await?;
+    db.prepare(P_STMT.GET.NAME, P_STMT.GET.CQL).await?;
+    db.prepare(P_STMT.GET_MANY.NAME, P_STMT.GET_MANY.CQL).await?;
+    db.prepare(P_STMT.COUNT.NAME, P_STMT.COUNT.CQL).await?;
+}
+
+// User functions
+
+pub async fn insert(db, i) { // validation is not applicable
+    let idx = i % ROW_COUNT + OFFSET;
+    let partition = db.get_partition_info("main", idx).await;
+    partition.idx += OFFSET;
+    let pk = hash(partition.idx);
+    let ck = hash(idx);
+    if USE_PREPARED_STATEMENTS {
+        db.execute_prepared(P_STMT.INSERT.NAME, [pk, ck]).await?
+    } else {
+        db.execute(P_STMT.INSERT.CQL.replace(":pk", `${pk}`).replace(":ck", `${ck}`)).await?
+    }
+}
+
+pub async fn get(db, i) { // make sure that we have only 1 row no matter how big partitions
+    let idx = i % ROW_COUNT + OFFSET;
+    let partition = db.get_partition_info("main", idx).await;
+    partition.idx += OFFSET;
+    let pk = hash(partition.idx);
+    let custom_err = "custom very useful err msg for the 'get' function"; // optional
+    let validation_args = [1, custom_err];
+    if USE_PREPARED_STATEMENTS {
+        db.execute_prepared_with_validation(P_STMT.GET.NAME, [pk], validation_args).await?
+    } else {
+        db.execute_with_validation(P_STMT.GET.CQL.replace(":pk", `${pk}`), validation_args).await?
+    }
+}
+
+pub async fn get_many(db, i) { // make sure that we have rows num as expected
+    let idx = i % ROW_COUNT + OFFSET;
+    let partition = db.get_partition_info("main", idx).await;
+    partition.idx += OFFSET;
+    let pk = hash(partition.idx);
+    let max_limit = partition.rows_num + 10; // make it be bigger than the expected value
+    let custom_err = "custom very useful err msg for the 'get_many' function"; // optional
+    let validation_args = [partition.rows_num, partition.rows_num, custom_err];
+    if USE_PREPARED_STATEMENTS {
+        db.execute_prepared_with_validation(P_STMT.GET_MANY.NAME, [pk, max_limit], validation_args).await?
+    } else {
+        let cql = P_STMT.GET_MANY.CQL.replace(":pk", `${pk}`).replace(":max_limit", `${max_limit}`);
+        db.execute_with_validation(cql, validation_args).await?
+    }
+}
+
+pub async fn count(db, i) { // checks that 'select count' integer result equals to the expected value
+    let idx = i % ROW_COUNT + OFFSET;
+    let partition = db.get_partition_info("main", idx).await;
+    partition.idx += OFFSET;
+    let pk = hash(partition.idx);
+    let custom_err = "custom very useful err msg for 'count' function"; // optional
+    let validation_args = [partition.rows_num, partition.rows_num, custom_err];
+    if USE_PREPARED_STATEMENTS {
+        db.execute_prepared_with_validation(P_STMT.COUNT.NAME, [pk], validation_args).await?
+    } else {
+        db.execute_with_validation(P_STMT.COUNT.CQL.replace(":pk", `${pk}`), validation_args).await?
+    }
+}


### PR DESCRIPTION
With this change it now becomes possible to validate number of rows returned for common `select` and `select count(...)` queries.

Old `execute` and `execute_prepared` context methods stay as is and following new methods are added:
- `execute_with_validation`
- `execute_prepared_with_validation`

These 2 new methods differ from existing 2 by having additional required parameter of `vector` type.
That `vector` parameter may have following element combinations:
- [Integer] -> Exact number of expected rows
- [Integer, Integer] -> Range of expected rows, both values are inclusive.
- [Integer, String] -> Exact number of expected rows and custom error message.
- [Integer, Integer, String] -> Range of expected rows and custom error message.

Example:
```
  pub async fn some_select_rune_function(db, i) {
    ...
    let elapsed = db.elapsed_secs();
    let rows_min = if elapsed > 100.0 { 0 } else { 1 };
    let rows_max = if elapsed < 150.0 { 1 } else { 0 };
    let custom_err = "rows must have been deleted by TTL after 100s-200s";
    db.execute_prepared_with_validation(
      PREPARED_STATEMENT_NAME,
      [pk],
      [rows_min, rows_max, custom_err],
    ).await?
  }
```

Above example shows how can we make sure that some our rows get deleted by TTL.
The 50 seconds of [0, 1] range shows how can we mitigate possible time measurement fluctuations.
Another possible approach is to depend on retries.

One more new context method, that is added in this scope, is `get_partition_info`.
It returns an object with 2 attributes - `idx` (index) and `rows_num`.

Example:
```
  pub async fn prepare(db) {
    db.init_partition_row_distribution_preset(
      "main", ROW_COUNT, ROWS_PER_PARTITION, PARTITION_SIZES).await?;
    ...
  }

  pub async fn some_select_rune_function(db, i) {
    let idx = i % ROW_COUNT + OFFSET;
    let partition = db.get_partition_info("main", idx).await;
    partition.idx += OFFSET;
    db.execute_prepared_with_validation(
      PREPARED_STATEMENT_NAME,
      [pk],
      [partition.rows_num], // precise matching to calculated partition rows number
    ).await?
  }
```

Also, an example rune script is added at `workloads/validation.rn`
to be able to play with the new feature with minimal efforts.

Latte `run` command was extended with the new `--validation-strategy` option.
Examples:
```
  - latte run ... --validation-strategy=retry // default, retry validation errors
  - latte run ... --validation-strategy=fail-fast // stop stress on the very first validation error
  - latte run ... --validation-strategy=ignore // Print the error and go on
 ```