### PR TITLE
Bump the latte version to 0.30.0-scylladb

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1267,7 +1267,7 @@ dependencies = [
 
 [[package]]
 name = "latte-cli"
-version = "0.28.5-scylladb"
+version = "0.30.0-scylladb"
 dependencies = [
  "anyhow",
  "assert_approx_eq",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "latte-cli"
 description = "A database benchmarking tool for Apache Cassandra and ScyllaDB"
-version = "0.28.5-scylladb"
+version = "0.30.0-scylladb"
 authors = ["Piotr Kołaczkowski <pkolaczk@gmail.com>"]
 edition = "2021"
 readme = "README.md"


### PR DESCRIPTION
Current state of this project is not patch-y mostly as it was in the beginning of the work on this fork.
It now has set of unique features which are absent in the source project.
Part of it has different designs based on the different requirements to the project.

So, bump the project version to the `0.30.0-scylladb` directly
skipping the `0.29.0-scylladb` to highlight the feature-wise evolving.