### PR TITLE
Update rust version

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.84"
+channel = "1.85"
 components = ["clippy", "rustfmt", "cargo"]


### PR DESCRIPTION
It is needed to be able to update the dependencies versions.
Without the rust version change we get following kind of an error:
```
  error: cannot install package `cargo-nextest 0.9.97`, \
    it requires rustc 1.85 or newer, while the currently active rustc version is 1.84.1
```