### PR TITLE
Add possibility to define a preferred rack

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -190,6 +190,10 @@ pub struct ConnectionConf {
     #[clap(long("datacenter"), required = false)]
     pub datacenter: Option<String>,
 
+    /// Rack name
+    #[clap(long("rack"), required = false)]
+    pub rack: Option<String>,
+
     /// Default CQL query consistency level
     #[clap(long("consistency"), required = false, default_value = "LOCAL_QUORUM")]
     pub consistency: Consistency,

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -487,6 +487,9 @@ impl Display for RunConfigCmp<'_> {
             self.line("Datacenter", "", |conf| {
                 conf.connection.datacenter.clone().unwrap_or_default()
             }),
+            self.line("Rack", "", |conf| {
+                conf.connection.rack.clone().unwrap_or_default()
+            }),
             self.line("DB version", "", |conf| {
                 OptionDisplay(conf.db_version.clone())
             }),

--- a/src/scripting/connect.rs
+++ b/src/scripting/connect.rs
@@ -34,11 +34,21 @@ fn tls_context(conf: &&ConnectionConf) -> Result<Option<TlsContext>, CassError> 
 pub async fn connect(conf: &ConnectionConf) -> Result<Context, CassError> {
     let mut policy_builder = DefaultPolicy::builder().token_aware(true);
     let mut datacenter: String = "".to_string();
+    let mut rack: String = "".to_string();
     if let Some(dc) = &conf.datacenter {
-        policy_builder = policy_builder
-            .prefer_datacenter(dc.to_owned())
-            .permit_dc_failover(true);
+        if let Some(current_rack) = &conf.rack {
+            policy_builder = policy_builder
+                .prefer_datacenter_and_rack(dc.to_owned(), current_rack.to_owned())
+                .permit_dc_failover(true);
+            rack = current_rack.clone();
+        } else {
+            policy_builder = policy_builder
+                .prefer_datacenter(dc.to_owned())
+                .permit_dc_failover(true);
+        }
         datacenter = dc.clone();
+    } else if let Some(_rack) = &conf.rack {
+        panic!("Datacenter must also be defined when rack is defined");
     }
     let profile = ExecutionProfile::builder()
         .consistency(conf.consistency.scylla_consistency())
@@ -59,6 +69,7 @@ pub async fn connect(conf: &ConnectionConf) -> Result<Context, CassError> {
         Some(scylla_session),
         conf.page_size.get() as u64,
         datacenter,
+        rack,
         conf.retry_number,
         conf.retry_interval,
         conf.validation_strategy,

--- a/src/scripting/context.rs
+++ b/src/scripting/context.rs
@@ -212,6 +212,8 @@ pub struct Context {
     #[rune(get)]
     pub preferred_datacenter: String,
     #[rune(get)]
+    pub preferred_rack: String,
+    #[rune(get)]
     pub data: Value,
     pub rng: ThreadRng,
 }
@@ -230,6 +232,7 @@ impl Context {
         session: Option<Session>,
         page_size: u64,
         preferred_datacenter: String,
+        preferred_rack: String,
         retry_number: u64,
         retry_interval: RetryInterval,
         validation_strategy: ValidationStrategy,
@@ -246,6 +249,7 @@ impl Context {
             partition_row_presets: HashMap::new(),
             load_cycle_count: 0,
             preferred_datacenter,
+            preferred_rack,
             data: Value::Object(Shared::new(Object::new()).unwrap()),
             rng: rand::thread_rng(),
         }
@@ -269,6 +273,7 @@ impl Context {
             partition_row_presets: self.partition_row_presets.clone(),
             load_cycle_count: self.load_cycle_count,
             preferred_datacenter: self.preferred_datacenter.clone(),
+            preferred_rack: self.preferred_rack.clone(),
             data: deserialized,
             start_time: TryLock::new(*self.start_time.try_lock().unwrap()),
             rng: rand::thread_rng(),
@@ -996,7 +1001,7 @@ mod tests {
     ) {
         for (rows_per_partitions_base, rows_per_partitions_groups) in rows_per_partitions_base_and_groups_mapping {
             let mut ctxt: Context = Context::new(
-                None, 501, "foo-dc".to_string(), 0,
+                None, 501, "foo-dc".to_string(), "foo-rack".to_string(), 0,
                 RetryInterval::new("1,2").expect("failed to parse retry interval"),
                 ValidationStrategy::Ignore,
             );
@@ -1177,7 +1182,7 @@ mod tests {
         let name_foo: String = "foo".to_string();
         let name_bar: String = "bar".to_string();
         let mut ctxt: Context = Context::new(
-            None, 501, "foo-dc".to_string(), 0,
+            None, 501, "foo-dc".to_string(), "foo-rack".to_string(), 0,
             RetryInterval::new("1,2").expect("failed to parse retry interval"),
             ValidationStrategy::Ignore,
         );
@@ -1212,7 +1217,7 @@ mod tests {
         rows_per_partitions_groups: String,
     ) {
         let mut ctxt: Context = Context::new(
-            None, 501, "foo-dc".to_string(), 0,
+            None, 501, "foo-dc".to_string(), "".to_string(), 0,
             RetryInterval::new("1,2").expect("failed to parse retry interval"),
             ValidationStrategy::Ignore,
         );


### PR DESCRIPTION
Before it was possible to define only preferred `datacenter`.
Now add also possibility to define a preferred rack. 

Usage example:
```
 $ latte run ... --datacenter=foo --rack=bar
```