### PR TITLE
Add full support of serial consistency

### DIFF
--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -506,7 +506,13 @@ impl Display for RunConfigCmp<'_> {
                     .join(", ")
             }),
             self.line("Consistency", "", |conf| {
-                conf.connection.consistency.scylla_consistency().to_string()
+                conf.connection.consistency.consistency().to_string()
+            }),
+            self.line("Serial consistency", "", |conf| {
+                conf.connection
+                    .serial_consistency
+                    .serial_consistency()
+                    .to_string()
             }),
             self.line("Tags", "", |conf| conf.tags.iter().join(", ")),
         ];

--- a/src/scripting/connect.rs
+++ b/src/scripting/connect.rs
@@ -51,7 +51,8 @@ pub async fn connect(conf: &ConnectionConf) -> Result<Context, CassError> {
         panic!("Datacenter must also be defined when rack is defined");
     }
     let profile = ExecutionProfile::builder()
-        .consistency(conf.consistency.scylla_consistency())
+        .consistency(conf.consistency.consistency())
+        .serial_consistency(Some(conf.serial_consistency.serial_consistency()))
         .load_balancing_policy(policy_builder.build())
         .request_timeout(Some(conf.request_timeout))
         .build();


### PR DESCRIPTION
The https://github.com/scylladb/latte/pull/74 added support for serial consistency only partially - for general select queries.

Now add support for the second part - conditional write queries.

Closes: #80