### PR TITLE
Add possibility to generate a 32bit float value in rune scripts

### DIFF
--- a/src/scripting/functions.rs
+++ b/src/scripting/functions.rs
@@ -88,13 +88,23 @@ pub fn hash_range(i: i64, max: i64) -> i64 {
     hash_inner(i) % max
 }
 
-/// Generates a floating point value with normal distribution
+/// Generates a 64-bits floating point value with normal distribution
 #[rune::function]
 pub fn normal(i: i64, mean: f64, std_dev: f64) -> VmResult<f64> {
     let mut rng = SmallRng::seed_from_u64(i as u64);
     let distribution =
         vm_try!(Normal::new(mean, std_dev).map_err(|e| VmError::panic(format!("{e}"))));
     VmResult::Ok(distribution.sample(&mut rng))
+}
+
+/// Generates a 32-bits floating point value with normal distribution
+#[rune::function]
+pub fn normal_f32(i: i64, mean: f32, std_dev: f32) -> VmResult<f32> {
+    let mut rng = SmallRng::seed_from_u64(i as u64);
+    let distribution = vm_try!(
+        Normal::new(mean.into(), std_dev.into()).map_err(|e| VmError::panic(format!("{e}")))
+    );
+    VmResult::Ok(distribution.sample(&mut rng) as f32)
 }
 
 #[rune::function]

--- a/src/scripting/mod.rs
+++ b/src/scripting/mod.rs
@@ -67,6 +67,7 @@ fn try_install(
     latte_module.function_meta(functions::hash_select)?;
     latte_module.function_meta(functions::uuid)?;
     latte_module.function_meta(functions::normal)?;
+    latte_module.function_meta(functions::normal_f32)?;
     latte_module.function_meta(functions::uniform)?;
     latte_module.function_meta(functions::is_none)?;
 


### PR DESCRIPTION
Before we could generate only `f64` floating point values using `normal` latte utility function.
For the `double` CQL data type it will work just great.
But if we use it for the `float` CQL data type then it will be automatically truncated to `32b`.
It becomes a problem when we do data validation.

So, add one more latte utility function - `normal_f32`.
It does the same as `normal` just returns the `32b` floating point value instead of the `64b`.
As a result, DB will store the same value which we generate in rune script and want to compare/validate as part of the data validation.