### PR TITLE
Use OCI mediatype for building image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -56,7 +56,7 @@ jobs:
             --platform ${{ matrix.build.platform }} \
             --provenance false \
             --metadata-file metadata \
-            --output push-by-digest=true,type=image,push=true \
+            --output push-by-digest=true,type=image,oci-mediatypes=true,push=true \
             .
           echo "Metadata file info:"
           cat metadata

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update && apt-get install -y \
 FROM debian:trixie-slim AS production
 
 LABEL org.opencontainers.image.source="https://github.com/scylladb/latte"
-LABEL org.opencontainers.image.title="ScyllaDB latte"
+LABEL org.opencontainers.image.title="ScyllaDB latte benchmarking tool"
 
 COPY --from=builder /usr/src/app/target/release/latte /usr/local/bin/latte
 


### PR DESCRIPTION
It will make the multi-arch image have labels from Dockerfile,
which, on it's turn, will be used by such tools as `renovate`
to read release notes for docker tags of the latte project.