### PR TITLE
Add text file lines iterator

### DIFF
--- a/src/scripting/cql_types.rs
+++ b/src/scripting/cql_types.rs
@@ -2,7 +2,10 @@ use metrohash::MetroHash128;
 use rune::alloc::fmt::TryWrite;
 use rune::runtime::VmResult;
 use rune::{vm_write, Any};
+use std::fs::File;
 use std::hash::Hash;
+use std::io;
+use std::io::{BufRead, BufReader};
 use uuid::{Variant, Version};
 
 #[derive(Clone, Debug, Any)]
@@ -111,5 +114,72 @@ pub mod f64 {
     #[rune::function(instance)]
     pub fn clamp(value: f64, min: f64, max: f64) -> f64 {
         value.clamp(min, max)
+    }
+}
+
+/// Iterator that reads a file line by line and splits each line using the given delimiter.
+/// This provides memory-efficient processing of large files by yielding one split line at a time.
+#[derive(Any, Debug)]
+pub struct SplitLinesIterator {
+    reader: BufReader<File>,
+    delimiter: String,
+    maxsplit: i64,
+    do_trim: bool,
+    skip_empty: bool,
+}
+
+impl SplitLinesIterator {
+    pub fn new(
+        path: &str,
+        delimiter: &str,
+        maxsplit: i64,
+        do_trim: bool,
+        skip_empty: bool,
+    ) -> io::Result<Self> {
+        let file = File::open(path)
+            .map_err(|e| io::Error::new(e.kind(), format!("Failed to open file {path}: {e}")));
+        match file {
+            Ok(file) => {
+                let reader = BufReader::new(file);
+                Ok(SplitLinesIterator {
+                    reader,
+                    delimiter: delimiter.to_string(),
+                    maxsplit,
+                    do_trim,
+                    skip_empty,
+                })
+            }
+            Err(e) => {
+                panic!("{}", e)
+            }
+        }
+    }
+}
+
+impl Iterator for SplitLinesIterator {
+    type Item = io::Result<Vec<String>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let mut line = String::new();
+        match self.reader.read_line(&mut line) {
+            Ok(0) => None, // EOF
+            Ok(_) => {
+                let parts: Vec<String> = line
+                    .splitn(
+                        if self.maxsplit < 0 {
+                            usize::MAX
+                        } else {
+                            (self.maxsplit + 1).try_into().unwrap()
+                        },
+                        &self.delimiter,
+                    )
+                    .map(|s| if self.do_trim { s.trim() } else { s })
+                    .filter(|s| !(self.skip_empty && s.is_empty()))
+                    .map(|s| s.to_string())
+                    .collect();
+                Some(Ok(parts))
+            }
+            Err(e) => Some(Err(e)),
+        }
     }
 }

--- a/src/scripting/functions.rs
+++ b/src/scripting/functions.rs
@@ -1,6 +1,6 @@
 use crate::scripting::cass_error::{CassError, CassErrorKind};
 use crate::scripting::context::Context;
-use crate::scripting::cql_types::{Int8, Uuid};
+use crate::scripting::cql_types::{Int8, SplitLinesIterator, Uuid};
 use crate::scripting::Resources;
 use chrono::Utc;
 use metrohash::MetroHash64;
@@ -264,6 +264,70 @@ pub fn read_resource_words(path: &str) -> io::Result<Vec<String>> {
         .split(|c: char| !c.is_alphabetic())
         .map(|s| s.to_string())
         .collect())
+}
+
+#[rune::function(instance)]
+pub fn next(mut iter: Mut<SplitLinesIterator>) -> Option<io::Result<Vec<String>>> {
+    iter.next()
+}
+
+/// Creates an iterator that reads a file line by line and splits each line using the given delimiter.
+/// Returns an iterator that yields Vec<String> for each line allowing to skip empty elements.
+#[rune::function]
+pub fn read_split_lines_iter(
+    path: &str,
+    // NOTE: "params" expects following elements:
+    // delimiter: &str,
+    // maxsplit: i64,
+    // do_trim: bool,    // per element after split
+    // skip_empty: bool, // skip empty elements in a vector of a line substrings, empty vector possible
+    params: Vec<Value>,
+) -> io::Result<SplitLinesIterator> {
+    let mut delimiter: String = " ".to_string();
+    let mut maxsplit = -1;
+    let mut do_trim = true;
+    let mut skip_empty = true;
+    match params.as_slice() {
+        // (str): delimiter
+        [Value::String(custom_delimiter)] => {
+            delimiter = custom_delimiter.borrow_ref().unwrap().to_string();
+        }
+        // (int): maxsplit
+        [Value::Integer(custom_maxsplit)] => {
+            maxsplit = *custom_maxsplit;
+        }
+        // (bool): do_trim
+        [Value::Bool(custom_do_trim)] => {
+            do_trim = *custom_do_trim;
+        }
+        // (bool, bool): do_trim, skip_empty
+        [Value::Bool(custom_do_trim), Value::Bool(custom_skip_empty)] => {
+            do_trim = *custom_do_trim;
+            skip_empty = *custom_skip_empty;
+        }
+        // (str, int): delimiter, maxsplit
+        [Value::String(custom_delimiter), Value::Integer(custom_maxsplit)] => {
+            delimiter = custom_delimiter.borrow_ref().unwrap().to_string();
+            maxsplit = *custom_maxsplit;
+        }
+        // (str, int, bool): delimiter, maxsplit, do_trim
+        [Value::String(custom_delimiter), Value::Integer(custom_maxsplit), Value::Bool(custom_do_trim)] =>
+        {
+            delimiter = custom_delimiter.borrow_ref().unwrap().to_string();
+            maxsplit = *custom_maxsplit;
+            do_trim = *custom_do_trim;
+        }
+        // (str, int, bool, bool): delimiter, maxsplit, do_trim, skip_empty
+        [Value::String(custom_delimiter), Value::Integer(custom_maxsplit), Value::Bool(custom_do_trim), Value::Bool(custom_skip_empty)] =>
+        {
+            delimiter = custom_delimiter.borrow_ref().unwrap().to_string();
+            maxsplit = *custom_maxsplit;
+            do_trim = *custom_do_trim;
+            skip_empty = *custom_skip_empty;
+        }
+        _ => panic!("Invalid arguments for read_split_lines_iter"),
+    }
+    SplitLinesIterator::new(path, &delimiter, maxsplit, do_trim, skip_empty)
 }
 
 #[rune::function(instance)]

--- a/src/scripting/mod.rs
+++ b/src/scripting/mod.rs
@@ -1,5 +1,6 @@
 use crate::scripting::cass_error::CassError;
 use crate::scripting::context::Context;
+use crate::scripting::cql_types::SplitLinesIterator;
 use rune::{ContextError, Module};
 use rust_embed::RustEmbed;
 use std::collections::HashMap;
@@ -90,12 +91,17 @@ fn try_install(
     fs_module.function_meta(functions::read_resource_to_string)?;
     fs_module.function_meta(functions::read_resource_lines)?;
     fs_module.function_meta(functions::read_resource_words)?;
+    let mut iter_module = Module::default();
+    iter_module.ty::<SplitLinesIterator>()?;
+    fs_module.function_meta(functions::read_split_lines_iter)?;
+    iter_module.function_meta(functions::next)?;
 
     rune_ctx.install(&context_module)?;
     rune_ctx.install(&err_module)?;
     rune_ctx.install(&uuid_module)?;
     rune_ctx.install(&latte_module)?;
     rune_ctx.install(&fs_module)?;
+    rune_ctx.install(&iter_module)?;
 
     Ok(())
 }


### PR DESCRIPTION
All current solutions parse whole file and effectively double the RAM usage
because in most cases we need to process the results of parsed file.
So, add a new latte function called `read_split_lines_iter`
which iterates lines of a file, allows to split it into sub-strings
using a custom delimeter and skip empty elements.

Usage example:
```rust
    let path = "<path-to>/latte/resources/lorem_ipsum_full.txt";
    let delimiter = " ";
    let maxsplit = -1; // any negative means "no limit"
    let do_trim = true;
    let skip_empty = true;
    // NOTE: second element for the 'fs::read_split_lines_iter' may also be empty or partial.
    let file_iterator = fs::read_split_lines_iter(path, [delimiter, maxsplit, do_trim, skip_empty])?;
    let parsed_data = [];
    while let Some(words) = file_iterator.next() {
        let current_words = words?; // unwrap ok/err
        dbg!(current_words); // optional debug print out of the taken data
        if !current_words.is_empty() { // may be empty vector if all elements are filtered out
            parsed_data.push(current_words)
        }
    }
    dbg!(parsed_data); // optional debug print out of the processed data
```

So, main gain out of using this new function is
ability to use RAM more efficiently which allows to parse much bigger files having the same RAM size.