### PR TITLE
Add --no-retry CLI flag to disable all retry logic

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -238,6 +238,10 @@ pub struct ConnectionConf {
     )]
     pub retry_interval: RetryInterval,
 
+    /// Disable all retry logic, making every CQL error immediately fatal.
+    #[clap(long("no-retry"))]
+    pub no_retry: bool,
+
     /// Validation strategy is used in the following cases:
     /// - Defines the strategy for 'select' queries validation errors.
     ///   Gets applied when 'execute_prepared_with_validation'

--- a/src/scripting/alternator/connect.rs
+++ b/src/scripting/alternator/connect.rs
@@ -32,5 +32,6 @@ pub async fn connect(conf: &ConnectionConf) -> Result<Context, AlternatorError> 
         conf.retry_number,
         conf.retry_interval,
         conf.validation_strategy,
+        conf.no_retry,
     ))
 }

--- a/src/scripting/alternator/context.rs
+++ b/src/scripting/alternator/context.rs
@@ -19,6 +19,7 @@ pub struct Context {
     pub retry_number: u64,
     pub retry_interval: RetryInterval,
     pub validation_strategy: ValidationStrategy,
+    pub no_retry: bool,
     pub partition_row_presets: HashMap<String, RowDistributionPreset>,
     #[rune(get, set, add_assign, copy)]
     pub load_cycle_count: u64,
@@ -35,6 +36,7 @@ impl Context {
         retry_number: u64,
         retry_interval: RetryInterval,
         validation_strategy: ValidationStrategy,
+        no_retry: bool,
     ) -> Context {
         Context {
             client,
@@ -43,6 +45,7 @@ impl Context {
             retry_number,
             retry_interval,
             validation_strategy,
+            no_retry,
             partition_row_presets: HashMap::new(),
             load_cycle_count: 0,
             data: Value::Object(Shared::new(Object::new()).unwrap()),
@@ -59,6 +62,7 @@ impl Context {
             retry_number: self.retry_number,
             retry_interval: self.retry_interval,
             validation_strategy: self.validation_strategy,
+            no_retry: self.no_retry,
             partition_row_presets: self.partition_row_presets.clone(),
             load_cycle_count: self.load_cycle_count,
             data: deserialized,

--- a/src/scripting/row_distribution.rs
+++ b/src/scripting/row_distribution.rs
@@ -507,6 +507,7 @@ mod tests {
             None, 501, "foo-dc".to_string(), "foo-rack".to_string(), 0,
             RetryInterval::new("1,2").expect("failed to parse retry interval"),
             ValidationStrategy::Ignore,
+            false,
         )
     }
 
@@ -516,6 +517,7 @@ mod tests {
             None, 0,
             RetryInterval::new("1,2").expect("failed to parse retry interval"),
             ValidationStrategy::Ignore,
+            false,
         )
     }
 


### PR DESCRIPTION
## Summary
- Adds a `--no-retry` boolean flag to `ConnectionConf`, available on `schema`, `load`, and `run` subcommands
- When enabled, disables driver-level retries via `FallthroughRetryPolicy` and makes every CQL error immediately fatal at the context and workload layers
- Overloaded errors are propagated instead of silently swallowed, validation retries are skipped, and custom errors are always fatal regardless of validation strategy

## Test plan
- [x] `make clippy` passes (including alternator and extended version info variants)
- [x] `make fmt-check` passes
- [x] `make build` succeeds
- [x] `cargo nextest run` — 58 tests pass (default features)
- [x] `cargo nextest run --no-default-features --features alternator` — 36 tests pass
- [x] `latte run --help` shows `--no-retry` flag