### PR TITLE
Implement Alternator API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,10 +6,17 @@ authors = ["Piotr Kołaczkowski <pkolaczk@gmail.com>"]
 edition = "2021"
 readme = "README.md"
 license = "Apache-2.0"
+default-run = "latte"
 
 [[bin]]
 name = "latte"
 path = "src/main.rs"
+required-features = ["cql"]
+
+[[bin]]
+name = "latte-alternator"
+path = "src/main.rs"
+required-features = ["alternator"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]

--- a/Makefile
+++ b/Makefile
@@ -29,3 +29,19 @@ clean:
 .PHONY: docker-build
 docker-build:
 	docker build --target production -t scylladb/latte:latest --compress .
+
+.PHONY: check-alternator
+check-alternator:
+	cargo check --all-targets --no-default-features --features alternator
+
+.PHONY: clippy-alternator
+clippy-alternator:
+	RUSTFLAGS=-Dwarnings cargo clippy --all-targets --no-default-features --features alternator
+
+.PHONY: test-alternator
+test-alternator:
+	cargo test --no-default-features --features alternator
+
+.PHONY: build-alternator
+build-alternator:
+	cargo build --examples --benches --no-default-features --features alternator

--- a/src/scripting/alternator/alternator_error.rs
+++ b/src/scripting/alternator/alternator_error.rs
@@ -1,7 +1,7 @@
 use rune::alloc::fmt::TryWrite;
 use rune::runtime::VmResult;
 use rune::{vm_write, Any};
-use std::fmt::{Display, Formatter};
+use std::fmt::{Debug, Display, Formatter};
 
 #[derive(Any, Debug)]
 pub struct AlternatorError(pub AlternatorErrorKind);
@@ -14,6 +14,7 @@ pub enum AlternatorErrorKind {
     PartitionRowPresetNotFound(String),
     CustomError(String),
     Error(String),
+    ConversionError(String),
 }
 
 impl AlternatorError {
@@ -47,11 +48,18 @@ impl Display for AlternatorError {
             AlternatorErrorKind::PartitionRowPresetNotFound(s) => {
                 write!(f, "Partition row preset not found: {s}")
             }
+            AlternatorErrorKind::ConversionError(s) => write!(f, "ConversionError: {s}"),
         }
     }
 }
 
 impl std::error::Error for AlternatorError {}
+
+impl From<rune::runtime::AccessError> for AlternatorError {
+    fn from(error: rune::runtime::AccessError) -> Self {
+        AlternatorError::new(AlternatorErrorKind::Error(error.to_string()))
+    }
+}
 
 pub type DbError = AlternatorError;
 pub type DbErrorKind = AlternatorErrorKind;

--- a/src/scripting/alternator/alternator_error.rs
+++ b/src/scripting/alternator/alternator_error.rs
@@ -1,6 +1,6 @@
 use aws_sdk_dynamodb::error::{ProvideErrorMetadata, SdkError};
 use rune::alloc::fmt::TryWrite;
-use rune::runtime::VmResult;
+use rune::runtime::{VmError, VmResult};
 use rune::{vm_write, Any};
 use std::fmt::{Debug, Display, Formatter};
 
@@ -88,6 +88,18 @@ where
         AlternatorError::new(AlternatorErrorKind::SdkError(
             err.message().unwrap_or("No message").to_string(),
         ))
+    }
+}
+
+impl From<VmError> for AlternatorError {
+    fn from(error: VmError) -> Self {
+        AlternatorError::new(AlternatorErrorKind::ConversionError(error.to_string()))
+    }
+}
+
+impl From<rune::alloc::Error> for AlternatorError {
+    fn from(error: rune::alloc::Error) -> Self {
+        AlternatorError::new(AlternatorErrorKind::ConversionError(error.to_string()))
     }
 }
 

--- a/src/scripting/alternator/alternator_error.rs
+++ b/src/scripting/alternator/alternator_error.rs
@@ -18,6 +18,7 @@ pub enum AlternatorErrorKind {
     SdkError(String),
     BadInput(String),
     ConversionError(String),
+    ValidationError(String),
 }
 
 impl AlternatorError {
@@ -54,6 +55,7 @@ impl Display for AlternatorError {
             AlternatorErrorKind::BadInput(s) => write!(f, "BadInput: {s}"),
             AlternatorErrorKind::SdkError(s) => write!(f, "SdkError: {s}"),
             AlternatorErrorKind::ConversionError(s) => write!(f, "ConversionError: {s}"),
+            AlternatorErrorKind::ValidationError(s) => write!(f, "ValidationError: {s}"),
         }
     }
 }

--- a/src/scripting/alternator/connect.rs
+++ b/src/scripting/alternator/connect.rs
@@ -1,6 +1,7 @@
 use super::alternator_error::{AlternatorError, AlternatorErrorKind};
 use super::context::Context;
 use crate::config::ConnectionConf;
+use aws_config::retry::RetryConfig;
 use aws_config::BehaviorVersion;
 use aws_sdk_dynamodb::config::{Credentials, Region};
 use aws_sdk_dynamodb::error::DisplayErrorContext;
@@ -14,6 +15,7 @@ pub async fn connect(conf: &ConnectionConf) -> Result<Context, AlternatorError> 
         .endpoint_url(&address)
         .region(Region::new("us-east-1"))
         .credentials_provider(Credentials::new("", "", None, None, ""))
+        .retry_config(RetryConfig::standard().with_max_attempts(1))
         .load()
         .await;
 
@@ -32,5 +34,6 @@ pub async fn connect(conf: &ConnectionConf) -> Result<Context, AlternatorError> 
         conf.retry_number,
         conf.retry_interval,
         conf.validation_strategy,
+        conf.page_size.get() as u64,
     ))
 }

--- a/src/scripting/alternator/context.rs
+++ b/src/scripting/alternator/context.rs
@@ -14,6 +14,7 @@ use try_lock::TryLock;
 #[derive(Any)]
 pub struct Context {
     client: Option<Client>,
+    page_size: u64,
     pub stats: TryLock<SessionStats>,
     pub start_time: TryLock<Instant>,
     pub retry_number: u64,
@@ -35,9 +36,11 @@ impl Context {
         retry_number: u64,
         retry_interval: RetryInterval,
         validation_strategy: ValidationStrategy,
+        page_size: u64,
     ) -> Context {
         Context {
             client,
+            page_size,
             stats: TryLock::new(SessionStats::new()),
             start_time: TryLock::new(Instant::now()),
             retry_number,
@@ -54,6 +57,7 @@ impl Context {
         let deserialized: Value = rmp_serde::from_slice(&serialized)?;
         Ok(Context {
             client: self.client.clone(),
+            page_size: self.page_size,
             stats: TryLock::new(SessionStats::default()),
             start_time: TryLock::new(*self.start_time.try_lock().unwrap()),
             retry_number: self.retry_number,
@@ -90,5 +94,9 @@ impl Context {
             .ok_or(AlternatorError::new(AlternatorErrorKind::Error(
                 "DynamoDB client is not initialized".to_string(),
             )))
+    }
+
+    pub fn get_page_size(&self) -> u64 {
+        self.page_size
     }
 }

--- a/src/scripting/alternator/context.rs
+++ b/src/scripting/alternator/context.rs
@@ -1,4 +1,4 @@
-use super::alternator_error::AlternatorError;
+use super::alternator_error::{AlternatorError, AlternatorErrorKind};
 use crate::config::{RetryInterval, ValidationStrategy};
 use crate::error::LatteError;
 use crate::scripting::cluster_info::ClusterInfo;
@@ -82,5 +82,13 @@ impl Context {
     pub fn reset(&self) {
         self.stats.try_lock().unwrap().reset();
         *self.start_time.try_lock().unwrap() = Instant::now();
+    }
+
+    pub fn get_client(&self) -> Result<&Client, AlternatorError> {
+        self.client
+            .as_ref()
+            .ok_or(AlternatorError::new(AlternatorErrorKind::Error(
+                "DynamoDB client is not initialized".to_string(),
+            )))
     }
 }

--- a/src/scripting/alternator/context.rs
+++ b/src/scripting/alternator/context.rs
@@ -69,11 +69,58 @@ impl Context {
         })
     }
 
+    /// Returns cluster metadata.
     pub async fn cluster_info(&self) -> Result<Option<ClusterInfo>, AlternatorError> {
-        Ok(Some(ClusterInfo {
-            name: "Alternator".to_string(),
-            db_version: "Alternator".to_string(),
-        }))
+        let client = self.get_client()?;
+
+        // Try ScyllaDB-specific system table via the alternator virtual interface
+        let scylla_result = client
+            .scan()
+            .table_name(".scylla.alternator.system.versions")
+            .projection_expression("version, build_id")
+            .send()
+            .await;
+
+        if let Ok(output) = scylla_result {
+            if let Some(items) = output.items {
+                if let Some(item) = items.first() {
+                    let version = item
+                        .get("version")
+                        .and_then(|v| v.as_s().ok().map(|s| s.as_ref()))
+                        .unwrap_or("unknown");
+
+                    let build_id = item
+                        .get("build_id")
+                        .and_then(|v| v.as_s().ok().map(|s| s.as_ref()))
+                        .unwrap_or("unknown");
+
+                    return Ok(Some(ClusterInfo {
+                        name: "".to_string(),
+                        db_version: format!("ScyllaDB {version} with build-id {build_id}"),
+                    }));
+                }
+            }
+        }
+
+        // If the ScyllaDB-specific table is not available, try to determine if it's AWS.
+        let describe_endpoints = client.describe_endpoints().send().await;
+
+        if let Ok(output) = describe_endpoints {
+            let aws_endpoint = output
+                .endpoints()
+                .iter()
+                .find(|endpoint| endpoint.address().contains("amazonaws.com"));
+
+            if let Some(endpoint) = aws_endpoint {
+                return Ok(Some(ClusterInfo {
+                    name: endpoint.address().to_string(),
+                    db_version: "AWS DynamoDB".to_string(),
+                }));
+            }
+        }
+
+        // We couldn't determine the cluster info.
+        Ok(None)
     }
 
     pub fn take_session_stats(&self) -> SessionStats {

--- a/src/scripting/alternator/functions.rs
+++ b/src/scripting/alternator/functions.rs
@@ -1,5 +1,6 @@
+use crate::config::ValidationStrategy;
 use crate::scripting::alternator::traits::{AlternatorRequest, IntoAlternatorOutput};
-use crate::scripting::functions_common::extract_validation_args;
+use crate::scripting::functions_common::{extract_validation_args, ValidationArgs};
 use crate::scripting::retry_error::handle_retry_error;
 
 use super::alternator_error::{AlternatorError, AlternatorErrorKind};
@@ -132,6 +133,50 @@ async fn handle_request(
         };
     }
     Err(AlternatorError::query_retries_exceeded(ctx.retry_number))
+}
+
+async fn handle_request_with_validation(
+    ctx: &Context,
+    builder: impl AlternatorRequest,
+    validation: Option<ValidationArgs>,
+    operation_name: &str,
+) -> Result<Vec<Value>, AlternatorError> {
+    let mut current_attempt_num: u64 = 0;
+    loop {
+        let result = handle_request(ctx, builder.clone()).await?;
+
+        let validation = match validation {
+            None => return Ok(result),
+            Some(ref v) => v,
+        };
+
+        let item_count = result.len() as u64;
+        if item_count >= validation.expected_min && item_count <= validation.expected_max {
+            return Ok(result);
+        }
+
+        let current_error = AlternatorError::new(AlternatorErrorKind::ValidationError(format!(
+            "{operation_name} returned {item_count} items, expected between {} and {} {}",
+            validation.expected_min, validation.expected_max, validation.custom_err_msg
+        )));
+
+        match ctx.validation_strategy {
+            ValidationStrategy::Retry => {
+                if current_attempt_num >= ctx.retry_number {
+                    return Err(current_error);
+                }
+                handle_retry_error(ctx, current_attempt_num, current_error).await;
+                current_attempt_num += 1;
+            }
+            ValidationStrategy::FailFast => {
+                return Err(current_error);
+            }
+            ValidationStrategy::Ignore => {
+                handle_retry_error(ctx, current_attempt_num, current_error).await;
+                return Ok(result);
+            }
+        }
+    }
 }
 
 /// Creates a new table.
@@ -442,19 +487,7 @@ pub async fn query(
         None
     };
 
-    let result = handle_request(&ctx, builder).await?;
-    let item_count = result.len() as u64;
-
-    if let Some(validation) = validation {
-        if item_count < validation.expected_min || item_count > validation.expected_max {
-            return Err(AlternatorError::new(AlternatorErrorKind::ValidationError(
-                format!(
-                    "Query returned {item_count} items, expected between {} and {} {}",
-                    validation.expected_min, validation.expected_max, validation.custom_err_msg
-                ),
-            )));
-        }
-    }
+    let result = handle_request_with_validation(&ctx, builder, validation, "Query").await?;
 
     if let Some(Value::Bool(with_result)) = params.get("with_result") {
         if *with_result {
@@ -525,19 +558,7 @@ pub async fn scan(
         None
     };
 
-    let result = handle_request(&ctx, builder).await?;
-    let item_count = result.len() as u64;
-
-    if let Some(validation) = validation {
-        if item_count < validation.expected_min || item_count > validation.expected_max {
-            return Err(AlternatorError::new(AlternatorErrorKind::ValidationError(
-                format!(
-                    "Scan returned {item_count} items, expected between {} and {} {}",
-                    validation.expected_min, validation.expected_max, validation.custom_err_msg
-                ),
-            )));
-        }
-    }
+    let result = handle_request_with_validation(&ctx, builder, validation, "Scan").await?;
 
     if let Some(Value::Bool(with_result)) = params.get("with_result") {
         if *with_result {

--- a/src/scripting/alternator/functions.rs
+++ b/src/scripting/alternator/functions.rs
@@ -1,16 +1,21 @@
+use crate::scripting::alternator::traits::{AlternatorRequest, IntoAlternatorOutput};
 use crate::scripting::functions_common::extract_validation_args;
+use crate::scripting::retry_error::handle_retry_error;
 
 use super::alternator_error::{AlternatorError, AlternatorErrorKind};
 use super::context::Context;
-use super::types::{alternator_map_to_rune_object, rune_object_to_alternator_map};
+use super::types::rune_object_to_alternator_map;
 use aws_sdk_dynamodb::client::Waiters;
 use aws_sdk_dynamodb::types::{
     AttributeDefinition, KeySchemaElement, KeyType, ScalarAttributeType,
 };
 use rune::runtime::{Object, Ref, Shared};
 use rune::{ToValue, Value};
+use std::cmp::min;
 use std::collections::HashMap;
 use std::ops::Deref;
+use std::time::Duration;
+use tokio::time::Instant;
 
 fn bad_input<T>(msg: impl Into<String>) -> Result<T, AlternatorError> {
     Err(AlternatorError::new(AlternatorErrorKind::BadInput(
@@ -65,6 +70,70 @@ fn extract_attribute_names(
         .collect::<Result<_, _>>()
 }
 
+async fn handle_request(
+    ctx: &Context,
+    builder: impl AlternatorRequest,
+) -> Result<Vec<Value>, AlternatorError> {
+    let mut token: Option<HashMap<String, aws_sdk_dynamodb::types::AttributeValue>> = None;
+    let mut current_attempt_num = 0;
+    let mut all_pages_duration = Duration::ZERO;
+    let mut all_items = Vec::new();
+    let mut total_item_count = 0;
+    let query_limit = builder.get_limit_val();
+
+    while current_attempt_num <= ctx.retry_number {
+        let mut current_builder = builder.clone();
+        if builder.has_pagination() {
+            let page_size = match query_limit {
+                Some(limit) => min(ctx.get_page_size() as i32, limit - total_item_count as i32),
+                None => ctx.get_page_size() as i32,
+            };
+            current_builder = current_builder.set_pagination(token.clone(), Some(page_size));
+        }
+
+        let start_time = ctx.stats.try_lock().unwrap().start_request();
+        let resp = current_builder.send().await;
+        let duration = Instant::now() - start_time;
+
+        match resp.into_output() {
+            Ok((page_items, item_count, next_token)) => {
+                all_pages_duration += duration;
+                all_items.extend(page_items);
+                total_item_count += item_count;
+                token = next_token;
+
+                if let Some(limit) = query_limit {
+                    if total_item_count as i32 >= limit {
+                        ctx.stats
+                            .try_lock()
+                            .unwrap()
+                            .complete_request(all_pages_duration, total_item_count);
+                        return Ok(all_items);
+                    }
+                }
+
+                if token.is_some() && builder.has_pagination() {
+                    current_attempt_num = 0; // reset retries for next page
+                    continue;
+                }
+
+                ctx.stats
+                    .try_lock()
+                    .unwrap()
+                    .complete_request(all_pages_duration, total_item_count);
+                return Ok(all_items);
+            }
+            Err(e) => {
+                let current_error = e;
+                handle_retry_error(ctx, current_attempt_num, current_error).await;
+                current_attempt_num += 1;
+                continue; // try again the same page
+            }
+        };
+    }
+    Err(AlternatorError::query_retries_exceeded(ctx.retry_number))
+}
+
 /// Creates a new table.
 ///
 /// # Arguments
@@ -102,7 +171,10 @@ pub async fn create_table(
         _ => None,
     };
 
-    let mut builder = client.create_table().table_name(table_name.deref());
+    let mut builder = client
+        .create_table()
+        .table_name(table_name.deref())
+        .billing_mode(aws_sdk_dynamodb::types::BillingMode::PayPerRequest);
 
     builder = builder.key_schema(
         KeySchemaElement::builder()
@@ -134,10 +206,7 @@ pub async fn create_table(
         );
     }
 
-    builder
-        .billing_mode(aws_sdk_dynamodb::types::BillingMode::PayPerRequest)
-        .send()
-        .await?;
+    builder.send().await?;
 
     client
         .wait_until_table_exists()
@@ -175,12 +244,12 @@ pub async fn put(
 ) -> Result<(), AlternatorError> {
     let client = ctx.get_client()?;
 
-    client
+    let builder = client
         .put_item()
         .table_name(table_name.deref())
-        .set_item(Some(rune_object_to_alternator_map(item)?))
-        .send()
-        .await?;
+        .set_item(Some(rune_object_to_alternator_map(item)?));
+
+    handle_request(&ctx, builder).await?;
 
     Ok(())
 }
@@ -199,12 +268,12 @@ pub async fn delete(
 ) -> Result<(), AlternatorError> {
     let client = ctx.get_client()?;
 
-    client
+    let builder = client
         .delete_item()
         .table_name(table_name.deref())
-        .set_key(Some(rune_object_to_alternator_map(key)?))
-        .send()
-        .await?;
+        .set_key(Some(rune_object_to_alternator_map(key)?));
+
+    handle_request(&ctx, builder).await?;
 
     Ok(())
 }
@@ -243,17 +312,12 @@ pub async fn get(
         }
     }
 
-    let output = builder.send().await?;
+    let result = handle_request(&ctx, builder).await?;
 
     if let Value::Object(opts) = &options {
         if let Some(Value::Bool(with_result)) = opts.borrow_ref()?.get("with_result") {
             if *with_result {
-                return Ok(output
-                    .item
-                    .map(alternator_map_to_rune_object)
-                    .transpose()?
-                    .to_value()
-                    .into_result()?);
+                return Ok(result.into_iter().next().to_value().into_result()?);
             }
         }
     }
@@ -300,7 +364,7 @@ pub async fn update(
         )?));
     }
 
-    builder.send().await?;
+    handle_request(&ctx, builder).await?;
 
     Ok(())
 }
@@ -378,11 +442,10 @@ pub async fn query(
         None
     };
 
-    let output = builder.send().await?;
+    let result = handle_request(&ctx, builder).await?;
+    let item_count = result.len() as u64;
 
     if let Some(validation) = validation {
-        let item_count = output.items().len() as u64;
-
         if item_count < validation.expected_min || item_count > validation.expected_max {
             return Err(AlternatorError::new(AlternatorErrorKind::ValidationError(
                 format!(
@@ -395,14 +458,7 @@ pub async fn query(
 
     if let Some(Value::Bool(with_result)) = params.get("with_result") {
         if *with_result {
-            return Ok(output
-                .items
-                .unwrap_or_default()
-                .into_iter()
-                .map(alternator_map_to_rune_object)
-                .collect::<Result<Vec<_>, _>>()?
-                .to_value()
-                .into_result()?);
+            return Ok(result.to_value().into_result()?);
         }
     }
 

--- a/src/scripting/alternator/functions.rs
+++ b/src/scripting/alternator/functions.rs
@@ -2,13 +2,13 @@ use crate::scripting::functions_common::extract_validation_args;
 
 use super::alternator_error::{AlternatorError, AlternatorErrorKind};
 use super::context::Context;
-use super::types::rune_object_to_alternator_map;
+use super::types::{alternator_map_to_rune_object, rune_object_to_alternator_map};
 use aws_sdk_dynamodb::client::Waiters;
 use aws_sdk_dynamodb::types::{
     AttributeDefinition, KeySchemaElement, KeyType, ScalarAttributeType,
 };
 use rune::runtime::{Object, Ref, Shared};
-use rune::Value;
+use rune::{ToValue, Value};
 use std::collections::HashMap;
 use std::ops::Deref;
 
@@ -213,19 +213,23 @@ pub async fn delete(
 ///
 /// The `options` object can be replaced with `()` if no options are needed.
 ///
+/// If `with_result` is set to true, an `Option<Value>` containing the item if present is returned.
+/// Otherwise the unit value is returned.
+///
 /// # Arguments
 /// * `table_name` - The name of the table.
 /// * `key` - The primary key of the item to get. An object containing the partition key
 ///   (and sort key if the table has one).
 /// * `options` - Optional parameters object:
 ///   - `consistent_read`: Boolean to enable consistent read (default: false).
+///   - `with_result`: If true, the result item is returned (default: false).
 #[rune::function(instance)]
 pub async fn get(
     ctx: Ref<Context>,
     table_name: Ref<str>,
     key: Ref<Object>,
     options: Value,
-) -> Result<(), AlternatorError> {
+) -> Result<Value, AlternatorError> {
     let client = ctx.get_client()?;
 
     let mut builder = client
@@ -233,15 +237,28 @@ pub async fn get(
         .table_name(table_name.deref())
         .set_key(Some(rune_object_to_alternator_map(key)?));
 
-    if let Value::Object(opts) = options {
-        if let Some(Value::Bool(consistent_read)) = opts.into_ref()?.get("consistent_read") {
+    if let Value::Object(opts) = &options {
+        if let Some(Value::Bool(consistent_read)) = opts.borrow_ref()?.get("consistent_read") {
             builder = builder.consistent_read(*consistent_read);
         }
     }
 
-    builder.send().await?;
+    let output = builder.send().await?;
 
-    Ok(())
+    if let Value::Object(opts) = &options {
+        if let Some(Value::Bool(with_result)) = opts.borrow_ref()?.get("with_result") {
+            if *with_result {
+                return Ok(output
+                    .item
+                    .map(alternator_map_to_rune_object)
+                    .transpose()?
+                    .to_value()
+                    .into_result()?);
+            }
+        }
+    }
+
+    Ok(Value::EmptyTuple)
 }
 
 /// Updates an item in the table.
@@ -307,12 +324,13 @@ pub async fn update(
 ///   - `consistent_read`: Boolean to enable consistent read (default: false).
 ///   - `limit`: The maximum number of items to evaluate (optional).
 ///   - `validation`: An optional item count validation. Look at [extract_validation_args] for details.
+///   - `with_result`: If true, the query result is returned (default: false).
 #[rune::function(instance)]
 pub async fn query(
     ctx: Ref<Context>,
     table_name: Ref<str>,
     params: Ref<Object>,
-) -> Result<(), AlternatorError> {
+) -> Result<Value, AlternatorError> {
     let client = ctx.get_client()?;
 
     let mut builder = client.query().table_name(table_name.deref());
@@ -375,5 +393,18 @@ pub async fn query(
         }
     }
 
-    Ok(())
+    if let Some(Value::Bool(with_result)) = params.get("with_result") {
+        if *with_result {
+            return Ok(output
+                .items
+                .unwrap_or_default()
+                .into_iter()
+                .map(alternator_map_to_rune_object)
+                .collect::<Result<Vec<_>, _>>()?
+                .to_value()
+                .into_result()?);
+        }
+    }
+
+    Ok(Value::EmptyTuple)
 }

--- a/src/scripting/alternator/functions.rs
+++ b/src/scripting/alternator/functions.rs
@@ -1,3 +1,5 @@
+use crate::scripting::functions_common::extract_validation_args;
+
 use super::alternator_error::{AlternatorError, AlternatorErrorKind};
 use super::context::Context;
 use super::types::rune_object_to_alternator_map;
@@ -304,6 +306,7 @@ pub async fn update(
 ///   - `attribute_values`: A map of attribute value placeholders (starting with :) to values.
 ///   - `consistent_read`: Boolean to enable consistent read (default: false).
 ///   - `limit`: The maximum number of items to evaluate (optional).
+///   - `validation`: An optional item count validation. Look at [extract_validation_args] for details.
 #[rune::function(instance)]
 pub async fn query(
     ctx: Ref<Context>,
@@ -348,7 +351,29 @@ pub async fn query(
         });
     }
 
-    builder.send().await?;
+    let validation = if let Some(Value::Vec(validation)) = params.get("validation") {
+        Some(
+            extract_validation_args(validation.borrow_ref()?.to_vec())
+                .map_err(|s| AlternatorError::new(AlternatorErrorKind::BadInput(s)))?,
+        )
+    } else {
+        None
+    };
+
+    let output = builder.send().await?;
+
+    if let Some(validation) = validation {
+        let item_count = output.items().len() as u64;
+
+        if item_count < validation.expected_min || item_count > validation.expected_max {
+            return Err(AlternatorError::new(AlternatorErrorKind::ValidationError(
+                format!(
+                    "Query returned {item_count} items, expected between {} and {} {}",
+                    validation.expected_min, validation.expected_max, validation.custom_err_msg
+                ),
+            )));
+        }
+    }
 
     Ok(())
 }

--- a/src/scripting/alternator/functions.rs
+++ b/src/scripting/alternator/functions.rs
@@ -1,0 +1,354 @@
+use super::alternator_error::{AlternatorError, AlternatorErrorKind};
+use super::context::Context;
+use super::types::rune_object_to_alternator_map;
+use aws_sdk_dynamodb::client::Waiters;
+use aws_sdk_dynamodb::types::{
+    AttributeDefinition, KeySchemaElement, KeyType, ScalarAttributeType,
+};
+use rune::runtime::{Object, Ref, Shared};
+use rune::Value;
+use std::collections::HashMap;
+use std::ops::Deref;
+
+fn bad_input<T>(msg: impl Into<String>) -> Result<T, AlternatorError> {
+    Err(AlternatorError::new(AlternatorErrorKind::BadInput(
+        msg.into(),
+    )))
+}
+
+/// Gets the name and type of a primary or sort key from a object.
+fn extract_key_definition(
+    object: &Shared<Object>,
+) -> Result<(String, ScalarAttributeType), AlternatorError> {
+    let key_name = if let Some(Value::String(s)) = object.borrow_ref()?.get("name") {
+        s.borrow_ref()?.to_string()
+    } else {
+        return bad_input("Key definition object must have a 'name' field");
+    };
+
+    let key_type = if let Some(Value::String(t)) = object.borrow_ref()?.get("type") {
+        match t.borrow_ref()?.as_str() {
+            "N" => ScalarAttributeType::N,
+            "S" => ScalarAttributeType::S,
+            "B" => ScalarAttributeType::B,
+            other => {
+                return bad_input(format!(
+                    "Invalid key type: {}, only N, S, and B are allowed.",
+                    other
+                ))
+            }
+        }
+    } else {
+        return bad_input("Key definition object must have a 'type' field");
+    };
+
+    Ok((key_name, key_type))
+}
+
+fn extract_attribute_names(
+    object: &Shared<Object>,
+) -> Result<HashMap<String, String>, AlternatorError> {
+    object
+        .borrow_ref()?
+        .iter()
+        .map(|(k, v)| {
+            Ok((
+                k.to_string(),
+                match v {
+                    Value::String(s) => s.borrow_ref()?.to_string(),
+                    _ => return bad_input("Attribute names must be strings"),
+                },
+            ))
+        })
+        .collect::<Result<_, _>>()
+}
+
+/// Creates a new table.
+///
+/// # Arguments
+/// * `table_name` - The name of the table to create.
+/// * `params` - Table definition parameters. Can be a string (defining just the primary key name) or an object containing:
+///   - `primary_key`: The primary key definition. Can be a string (name) or an object with `name` and `type`.
+///   - `sort_key`: The sort key definition (optional). Can be a string (name) or an object with `name` and `type`.
+#[rune::function(instance)]
+pub async fn create_table(
+    ctx: Ref<Context>,
+    table_name: Ref<str>,
+    params: Value,
+) -> Result<(), AlternatorError> {
+    let client = ctx.get_client()?;
+
+    // Extract primary key definition
+    let (pk_name, pk_type) = match &params {
+        Value::String(s) => (s.borrow_ref()?.to_string(), ScalarAttributeType::S),
+        Value::Object(o) => match o.borrow_ref()?.get("primary_key") {
+            Some(Value::String(s)) => (s.borrow_ref()?.to_string(), ScalarAttributeType::S),
+            Some(Value::Object(pk_obj)) => extract_key_definition(pk_obj)?,
+            _ => return bad_input("Invalid 'primary_key' object in params"),
+        },
+        _ => return bad_input("Params must be a string or an object"),
+    };
+
+    // Extract sort key definition if present
+    let sk = match &params {
+        Value::Object(o) => match o.borrow_ref()?.get("sort_key") {
+            Some(Value::String(s)) => Some((s.borrow_ref()?.to_string(), ScalarAttributeType::S)),
+            Some(Value::Object(sk_obj)) => Some(extract_key_definition(sk_obj)?),
+            Some(_) => return bad_input("Invalid 'sort_key' object in params"),
+            None => None,
+        },
+        _ => None,
+    };
+
+    let mut builder = client.create_table().table_name(table_name.deref());
+
+    builder = builder.key_schema(
+        KeySchemaElement::builder()
+            .attribute_name(pk_name.clone())
+            .key_type(KeyType::Hash)
+            .build()?,
+    );
+
+    builder = builder.attribute_definitions(
+        AttributeDefinition::builder()
+            .attribute_name(pk_name)
+            .attribute_type(pk_type)
+            .build()?,
+    );
+
+    if let Some((sk_name, sk_type)) = sk {
+        builder = builder.key_schema(
+            KeySchemaElement::builder()
+                .attribute_name(sk_name.clone())
+                .key_type(KeyType::Range)
+                .build()?,
+        );
+
+        builder = builder.attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name(sk_name)
+                .attribute_type(sk_type)
+                .build()?,
+        );
+    }
+
+    builder
+        .billing_mode(aws_sdk_dynamodb::types::BillingMode::PayPerRequest)
+        .send()
+        .await?;
+
+    client
+        .wait_until_table_exists()
+        .table_name(table_name.deref())
+        .wait(std::time::Duration::from_secs(15))
+        .await?;
+
+    Ok(())
+}
+
+/// Deletes a table.
+#[rune::function(instance)]
+pub async fn delete_table(ctx: Ref<Context>, table_name: Ref<str>) -> Result<(), AlternatorError> {
+    let client = ctx.get_client()?;
+
+    client
+        .delete_table()
+        .table_name(table_name.deref())
+        .send()
+        .await?;
+
+    Ok(())
+}
+
+/// Puts an item into the table.
+///
+/// # Arguments
+/// * `table_name` - The name of the table.
+/// * `item` - The item to insert. An object where keys are attribute names and values are attribute values.
+#[rune::function(instance)]
+pub async fn put(
+    ctx: Ref<Context>,
+    table_name: Ref<str>,
+    item: Ref<Object>,
+) -> Result<(), AlternatorError> {
+    let client = ctx.get_client()?;
+
+    client
+        .put_item()
+        .table_name(table_name.deref())
+        .set_item(Some(rune_object_to_alternator_map(item)?))
+        .send()
+        .await?;
+
+    Ok(())
+}
+
+/// Deletes an item from the table.
+///
+/// # Arguments
+/// * `table_name` - The name of the table.
+/// * `key` - The primary key of the item to delete. An object containing the partition key
+///   (and sort key if the table has one).
+#[rune::function(instance)]
+pub async fn delete(
+    ctx: Ref<Context>,
+    table_name: Ref<str>,
+    key: Ref<Object>,
+) -> Result<(), AlternatorError> {
+    let client = ctx.get_client()?;
+
+    client
+        .delete_item()
+        .table_name(table_name.deref())
+        .set_key(Some(rune_object_to_alternator_map(key)?))
+        .send()
+        .await?;
+
+    Ok(())
+}
+
+/// Gets an item from the table.
+///
+/// The `options` object can be replaced with `()` if no options are needed.
+///
+/// # Arguments
+/// * `table_name` - The name of the table.
+/// * `key` - The primary key of the item to get. An object containing the partition key
+///   (and sort key if the table has one).
+/// * `options` - Optional parameters object:
+///   - `consistent_read`: Boolean to enable consistent read (default: false).
+#[rune::function(instance)]
+pub async fn get(
+    ctx: Ref<Context>,
+    table_name: Ref<str>,
+    key: Ref<Object>,
+    options: Value,
+) -> Result<(), AlternatorError> {
+    let client = ctx.get_client()?;
+
+    let mut builder = client
+        .get_item()
+        .table_name(table_name.deref())
+        .set_key(Some(rune_object_to_alternator_map(key)?));
+
+    if let Value::Object(opts) = options {
+        if let Some(Value::Bool(consistent_read)) = opts.into_ref()?.get("consistent_read") {
+            builder = builder.consistent_read(*consistent_read);
+        }
+    }
+
+    builder.send().await?;
+
+    Ok(())
+}
+
+/// Updates an item in the table.
+///
+/// # Arguments
+/// * `table_name` - The name of the table.
+/// * `key` - The primary key of the item to update. An object containing the partition key
+///   (and sort key if the table has one).
+/// * `params` - Parameters for the update operation. An object containing:
+///   - `update`: The update expression string.
+///   - `attribute_names`: A map of attribute name placeholders (starting with #) to actual names.
+///   - `attribute_values`: A map of attribute value placeholders (starting with :) to values.
+#[rune::function(instance)]
+pub async fn update(
+    ctx: Ref<Context>,
+    table_name: Ref<str>,
+    key: Ref<Object>,
+    params: Ref<Object>,
+) -> Result<(), AlternatorError> {
+    let client = ctx.get_client()?;
+
+    let mut builder = client
+        .update_item()
+        .table_name(table_name.deref())
+        .set_key(Some(rune_object_to_alternator_map(key)?));
+
+    if let Some(Value::String(update_expression)) = params.get("update") {
+        builder = builder.update_expression(update_expression.borrow_ref()?.to_string());
+    }
+
+    if let Some(Value::Object(attr_names)) = params.get("attribute_names") {
+        builder =
+            builder.set_expression_attribute_names(Some(extract_attribute_names(attr_names)?));
+    }
+
+    if let Some(Value::Object(attr_values)) = params.get("attribute_values") {
+        builder = builder.set_expression_attribute_values(Some(rune_object_to_alternator_map(
+            attr_values.clone().into_ref()?,
+        )?));
+    }
+
+    builder.send().await?;
+
+    Ok(())
+}
+
+/// Queries items from the table.
+///
+/// Unlike `get`, which retrieves a single item by its exact primary key,
+/// `query` retrieves multiple items that share the same partition key.
+/// It also allows specifying conditions on the sort key and filtering the results based on non-key attributes.
+///
+/// If `with_result` is set to true, the query result is returned as a `Vec<Object>`.
+/// Otherwise, the unit value is returned.
+///
+/// # Arguments
+/// * `table_name` - The name of the table.
+/// * `params` - Parameters for the query operation. An object containing:
+///   - `query`: The key condition expression string (required).
+///   - `filter`: The filter expression string (optional, applied after query).
+///   - `attribute_names`: A map of attribute name placeholders (starting with #) to actual names.
+///   - `attribute_values`: A map of attribute value placeholders (starting with :) to values.
+///   - `consistent_read`: Boolean to enable consistent read (default: false).
+///   - `limit`: The maximum number of items to evaluate (optional).
+#[rune::function(instance)]
+pub async fn query(
+    ctx: Ref<Context>,
+    table_name: Ref<str>,
+    params: Ref<Object>,
+) -> Result<(), AlternatorError> {
+    let client = ctx.get_client()?;
+
+    let mut builder = client.query().table_name(table_name.deref());
+
+    if let Some(Value::String(key_condition_expression)) = params.get("query") {
+        builder =
+            builder.key_condition_expression(key_condition_expression.borrow_ref()?.to_string());
+    }
+
+    if let Some(Value::String(filter_expression)) = params.get("filter") {
+        builder = builder.filter_expression(filter_expression.borrow_ref()?.to_string());
+    }
+
+    if let Some(Value::Object(attr_names)) = params.get("attribute_names") {
+        builder =
+            builder.set_expression_attribute_names(Some(extract_attribute_names(attr_names)?));
+    }
+
+    if let Some(Value::Object(attr_values)) = params.get("attribute_values") {
+        builder = builder.set_expression_attribute_values(Some(rune_object_to_alternator_map(
+            attr_values.clone().into_ref()?,
+        )?));
+    }
+
+    if let Some(Value::Bool(consistent_read)) = params.get("consistent_read") {
+        builder = builder.consistent_read(*consistent_read);
+    }
+
+    if let Some(limit_val) = params.get("limit") {
+        builder = builder.limit(match limit_val {
+            Value::Integer(i) => match i32::try_from(*i) {
+                Ok(val) => val,
+                Err(_) => return bad_input("limit is out of range"),
+            },
+            _ => return bad_input("limit must be an integer"),
+        });
+    }
+
+    builder.send().await?;
+
+    Ok(())
+}

--- a/src/scripting/alternator/functions.rs
+++ b/src/scripting/alternator/functions.rs
@@ -464,3 +464,86 @@ pub async fn query(
 
     Ok(Value::EmptyTuple)
 }
+
+/// Scans items from the table.
+///
+/// If `with_result` is set to true, the scan result is returned as a `Vec<Object>`.
+/// Otherwise, the unit value is returned.
+///
+/// # Arguments
+/// * `table_name` - The name of the table.
+/// * `params` - Parameters for the scan operation. An object containing:
+///   - `filter`: The filter expression string (optional).
+///   - `attribute_names`: A map of attribute name placeholders (starting with #) to actual names.
+///   - `attribute_values`: A map of attribute value placeholders (starting with :) to values.
+///   - `consistent_read`: Boolean to enable consistent read (default: false).
+///   - `limit`: The maximum number of items to evaluate (optional).
+///   - `validation`: An optional item count validation. Look at [extract_validation_args] for details.
+///   - `with_result`: If true, the scan result is returned (default: false).
+#[rune::function(instance)]
+pub async fn scan(
+    ctx: Ref<Context>,
+    table_name: Ref<str>,
+    params: Ref<Object>,
+) -> Result<Value, AlternatorError> {
+    let client = ctx.get_client()?;
+
+    let mut builder = client.scan().table_name(table_name.deref());
+
+    if let Some(Value::String(filter_expression)) = params.get("filter") {
+        builder = builder.filter_expression(filter_expression.borrow_ref()?.to_string());
+    }
+
+    if let Some(Value::Object(attr_names)) = params.get("attribute_names") {
+        builder =
+            builder.set_expression_attribute_names(Some(extract_attribute_names(attr_names)?));
+    }
+
+    if let Some(Value::Object(attr_values)) = params.get("attribute_values") {
+        builder = builder.set_expression_attribute_values(Some(rune_object_to_alternator_map(
+            attr_values.clone().into_ref()?,
+        )?));
+    }
+
+    if let Some(Value::Bool(consistent_read)) = params.get("consistent_read") {
+        builder = builder.consistent_read(*consistent_read);
+    }
+
+    if let Some(limit_val) = params.get("limit") {
+        builder = builder.limit(match limit_val {
+            Value::Integer(i) => *i as i32,
+            _ => return bad_input("limit must be an integer"),
+        });
+    }
+
+    let validation = if let Some(Value::Vec(validation)) = params.get("validation") {
+        Some(
+            extract_validation_args(validation.borrow_ref()?.to_vec())
+                .map_err(|s| AlternatorError::new(AlternatorErrorKind::BadInput(s)))?,
+        )
+    } else {
+        None
+    };
+
+    let result = handle_request(&ctx, builder).await?;
+    let item_count = result.len() as u64;
+
+    if let Some(validation) = validation {
+        if item_count < validation.expected_min || item_count > validation.expected_max {
+            return Err(AlternatorError::new(AlternatorErrorKind::ValidationError(
+                format!(
+                    "Scan returned {item_count} items, expected between {} and {} {}",
+                    validation.expected_min, validation.expected_max, validation.custom_err_msg
+                ),
+            )));
+        }
+    }
+
+    if let Some(Value::Bool(with_result)) = params.get("with_result") {
+        if *with_result {
+            return Ok(result.to_value().into_result()?);
+        }
+    }
+
+    Ok(Value::EmptyTuple)
+}

--- a/src/scripting/alternator/mod.rs
+++ b/src/scripting/alternator/mod.rs
@@ -1,3 +1,4 @@
 pub mod alternator_error;
 pub mod connect;
 pub mod context;
+pub mod types;

--- a/src/scripting/alternator/mod.rs
+++ b/src/scripting/alternator/mod.rs
@@ -2,4 +2,5 @@ pub mod alternator_error;
 pub mod connect;
 pub mod context;
 pub mod functions;
+mod traits;
 pub mod types;

--- a/src/scripting/alternator/mod.rs
+++ b/src/scripting/alternator/mod.rs
@@ -1,4 +1,5 @@
 pub mod alternator_error;
 pub mod connect;
 pub mod context;
+pub mod functions;
 pub mod types;

--- a/src/scripting/alternator/traits.rs
+++ b/src/scripting/alternator/traits.rs
@@ -1,0 +1,152 @@
+use super::alternator_error::AlternatorError;
+use super::types::alternator_map_to_rune_object;
+use aws_sdk_dynamodb::error::{ProvideErrorMetadata, SdkError};
+use aws_sdk_dynamodb::operation::{
+    create_table::CreateTableOutput, delete_item::DeleteItemOutput,
+    delete_table::DeleteTableOutput, get_item::GetItemOutput, put_item::PutItemOutput,
+    query::QueryOutput, update_item::UpdateItemOutput,
+};
+use aws_sdk_dynamodb::types::AttributeValue;
+use rune::Value;
+use std::collections::HashMap;
+use std::future::Future;
+
+pub(super) type AlternatorOutputResult =
+    Result<(Vec<Value>, u64, Option<HashMap<String, AttributeValue>>), AlternatorError>;
+
+pub(super) trait IntoAlternatorOutput {
+    fn into_output(self) -> AlternatorOutputResult;
+}
+
+impl IntoAlternatorOutput for GetItemOutput {
+    fn into_output(self) -> AlternatorOutputResult {
+        if let Some(item) = self.item {
+            Ok((vec![alternator_map_to_rune_object(item)?], 1, None))
+        } else {
+            Ok((vec![], 0, None))
+        }
+    }
+}
+
+impl IntoAlternatorOutput for QueryOutput {
+    fn into_output(self) -> AlternatorOutputResult {
+        let items = self.items.unwrap_or_default();
+        let mut result = Vec::with_capacity(items.len());
+        for item in items {
+            result.push(alternator_map_to_rune_object(item)?);
+        }
+        let len = result.len() as u64;
+        Ok((result, len, self.last_evaluated_key))
+    }
+}
+
+macro_rules! impl_into_alternator_output_empty {
+    ($($t:ty),*) => {
+        $(
+            impl IntoAlternatorOutput for $t {
+                fn into_output(self) -> AlternatorOutputResult {
+                    Ok((vec![], 0, None))
+                }
+            }
+        )*
+    };
+}
+
+impl_into_alternator_output_empty!(
+    PutItemOutput,
+    UpdateItemOutput,
+    DeleteItemOutput,
+    CreateTableOutput,
+    DeleteTableOutput
+);
+
+impl<T, E, R> IntoAlternatorOutput for Result<T, SdkError<E, R>>
+where
+    T: IntoAlternatorOutput,
+    E: ProvideErrorMetadata,
+{
+    fn into_output(self) -> AlternatorOutputResult {
+        match self {
+            Ok(val) => val.into_output(),
+            Err(err) => Err(AlternatorError::from(err)),
+        }
+    }
+}
+
+pub(super) trait SendRequest {
+    fn send(
+        self,
+    ) -> impl Future<
+        Output = Result<impl IntoAlternatorOutput, SdkError<impl ProvideErrorMetadata, impl Send>>,
+    >;
+}
+
+pub(super) trait AlternatorRequest: SendRequest + Clone {
+    fn set_pagination(
+        self,
+        token: Option<HashMap<String, AttributeValue>>,
+        limit: Option<i32>,
+    ) -> Self;
+    fn has_pagination(&self) -> bool;
+    fn get_limit_val(&self) -> Option<i32>;
+}
+
+macro_rules! impl_send_request {
+    ($($t:ty),*) => {
+        $(
+            impl SendRequest for $t {
+                fn send(
+                    self,
+                ) -> impl Future<
+                    Output = Result<impl IntoAlternatorOutput, SdkError<impl ProvideErrorMetadata, impl Send>>,
+                > {
+                    self.send()
+                }
+            }
+        )*
+    };
+}
+
+macro_rules! impl_alternator_request_no_pagination {
+    ($($t:ty),*) => {
+        $(
+            impl_send_request!($t);
+            impl AlternatorRequest for $t {
+                fn set_pagination(self, _: Option<HashMap<String, AttributeValue>>, _: Option<i32>) -> Self { self }
+                fn has_pagination(&self) -> bool { false }
+                fn get_limit_val(&self) -> Option<i32> { None }
+            }
+        )*
+    };
+}
+
+impl_alternator_request_no_pagination!(
+    aws_sdk_dynamodb::operation::create_table::builders::CreateTableFluentBuilder,
+    aws_sdk_dynamodb::operation::delete_table::builders::DeleteTableFluentBuilder,
+    aws_sdk_dynamodb::operation::put_item::builders::PutItemFluentBuilder,
+    aws_sdk_dynamodb::operation::delete_item::builders::DeleteItemFluentBuilder,
+    aws_sdk_dynamodb::operation::get_item::builders::GetItemFluentBuilder,
+    aws_sdk_dynamodb::operation::update_item::builders::UpdateItemFluentBuilder
+);
+
+impl_send_request!(aws_sdk_dynamodb::operation::query::builders::QueryFluentBuilder);
+
+impl AlternatorRequest for aws_sdk_dynamodb::operation::query::builders::QueryFluentBuilder {
+    fn set_pagination(
+        self,
+        token: Option<HashMap<String, AttributeValue>>,
+        limit: Option<i32>,
+    ) -> Self {
+        let mut b = self.set_exclusive_start_key(token);
+        if let Some(limit) = limit {
+            b = b.limit(limit);
+        }
+        b
+    }
+    fn has_pagination(&self) -> bool {
+        true
+    }
+    fn get_limit_val(&self) -> Option<i32> {
+        *self.get_limit()
+    }
+}

--- a/src/scripting/alternator/types.rs
+++ b/src/scripting/alternator/types.rs
@@ -1,0 +1,53 @@
+use super::alternator_error::{AlternatorError, AlternatorErrorKind};
+use aws_sdk_dynamodb::types::AttributeValue;
+use rune::runtime::{Object, Ref};
+use rune::Value;
+use std::collections::HashMap;
+
+pub fn rune_value_to_alternator_attribute(v: Value) -> Result<AttributeValue, AlternatorError> {
+    match v {
+        Value::Bool(b) => Ok(AttributeValue::Bool(b)),
+
+        // DynamoDB represents all numbers as strings
+        Value::Integer(i) => Ok(AttributeValue::N(i.to_string())),
+        // To distinguish floats from integers, we print them with the decimal point
+        Value::Float(f) => Ok(AttributeValue::N(format!("{:?}", f))),
+
+        Value::String(s) => Ok(AttributeValue::S(s.into_ref()?.to_string())),
+
+        Value::Bytes(b) => Ok(AttributeValue::B(b.into_ref()?.to_vec().into())),
+
+        Value::Vec(v) => Ok(AttributeValue::L(
+            v.into_ref()?
+                .iter()
+                .map(|v| rune_value_to_alternator_attribute(v.clone()))
+                .collect::<Result<_, _>>()?,
+        )),
+
+        Value::Object(o) => Ok(AttributeValue::M(rune_object_to_alternator_map(
+            o.into_ref()?,
+        )?)),
+
+        Value::Option(o) => match o.into_ref()?.as_ref() {
+            Some(v) => rune_value_to_alternator_attribute(v.clone()),
+            None => Ok(AttributeValue::Null(true)),
+        },
+
+        _ => Err(AlternatorError::new(AlternatorErrorKind::ConversionError(
+            format!("Unsupported Rune Value type for: {:?}", v),
+        ))),
+    }
+}
+
+pub fn rune_object_to_alternator_map(
+    o: Ref<Object>,
+) -> Result<HashMap<String, AttributeValue>, AlternatorError> {
+    o.iter()
+        .map(|(k, v)| {
+            Ok((
+                k.to_string(),
+                rune_value_to_alternator_attribute(v.clone())?,
+            ))
+        })
+        .collect()
+}

--- a/src/scripting/alternator/types.rs
+++ b/src/scripting/alternator/types.rs
@@ -1,7 +1,7 @@
 use super::alternator_error::{AlternatorError, AlternatorErrorKind};
 use aws_sdk_dynamodb::types::AttributeValue;
-use rune::runtime::{Object, Ref};
-use rune::Value;
+use rune::runtime::{Bytes, Object, Ref};
+use rune::{ToValue, Value};
 use std::collections::HashMap;
 
 pub fn rune_value_to_alternator_attribute(v: Value) -> Result<AttributeValue, AlternatorError> {
@@ -50,4 +50,53 @@ pub fn rune_object_to_alternator_map(
             ))
         })
         .collect()
+}
+
+pub fn alternator_attribute_to_rune_value(attr: AttributeValue) -> Result<Value, AlternatorError> {
+    match attr {
+        AttributeValue::Bool(b) => Ok(Value::Bool(b)),
+
+        AttributeValue::N(n) => {
+            // Try parsing as integer first, then as float
+            if let Ok(i) = n.parse::<i64>() {
+                Ok(Value::Integer(i))
+            } else if let Ok(f) = n.parse::<f64>() {
+                Ok(Value::Float(f))
+            } else {
+                Err(AlternatorError::new(AlternatorErrorKind::ConversionError(
+                    format!("Invalid number format: {}", n),
+                )))
+            }
+        }
+
+        AttributeValue::S(s) => Ok(s.as_str().to_value().into_result()?),
+
+        AttributeValue::B(b) => Ok(Bytes::try_from(b.into_inner())?.to_value().into_result()?),
+
+        AttributeValue::L(l) => Ok(l
+            .into_iter()
+            .map(alternator_attribute_to_rune_value)
+            .collect::<Result<Vec<Value>, _>>()?
+            .to_value()
+            .into_result()?),
+
+        AttributeValue::M(map) => Ok(alternator_map_to_rune_object(map)?),
+
+        AttributeValue::Null(_) => Ok(None::<bool>.to_value().into_result()?),
+
+        _ => Err(AlternatorError::new(AlternatorErrorKind::ConversionError(
+            format!("Unsupported Alternator AttributeValue type: {:?}", attr),
+        ))),
+    }
+}
+
+pub fn alternator_map_to_rune_object(
+    map: HashMap<String, AttributeValue>,
+) -> Result<Value, AlternatorError> {
+    Ok(map
+        .into_iter()
+        .map(|(k, v)| Ok((k, alternator_attribute_to_rune_value(v)?)))
+        .collect::<Result<HashMap<String, Value>, AlternatorError>>()?
+        .to_value()
+        .into_result()?)
 }

--- a/src/scripting/functions_common.rs
+++ b/src/scripting/functions_common.rs
@@ -41,6 +41,51 @@ pub fn param(
     Ok(rhs.into_token_stream(ctx)?)
 }
 
+pub struct ValidationArgs {
+    pub expected_min: u64,
+    pub expected_max: u64,
+    pub custom_err_msg: String,
+}
+
+/// Extracts validation arguments from the given vector of Values.
+///
+/// The expected formats are:
+///  * [Integer] -> Exact number of expected rows
+///  * [Integer, Integer] -> Range of expected rows, both values are inclusive.
+///  * [Integer, String] -> Exact number of expected rows and custom error message.
+///  * [Integer, Integer, String] -> Range of expected rows and custom error message.
+pub fn extract_validation_args(validation_args: Vec<Value>) -> Result<ValidationArgs, String> {
+    match validation_args.as_slice() {
+        // (int): expected_rows
+        [Value::Integer(expected_rows)] => Ok(ValidationArgs {
+            expected_min: *expected_rows as u64,
+            expected_max: *expected_rows as u64,
+            custom_err_msg: String::new(),
+        }),
+        // (int, int): expected_rows_num_min, expected_rows_num_max
+        [Value::Integer(min), Value::Integer(max)] => Ok(ValidationArgs {
+            expected_min: *min as u64,
+            expected_max: *max as u64,
+            custom_err_msg: String::new(),
+        }),
+        // (int, str): expected_rows, custom_err_msg
+        [Value::Integer(expected_rows), Value::String(custom_err_msg)] => Ok(ValidationArgs {
+            expected_min: *expected_rows as u64,
+            expected_max: *expected_rows as u64,
+            custom_err_msg: custom_err_msg.borrow_ref().unwrap().to_string(),
+        }),
+        // (int, int, str): expected_rows_num_min, expected_rows_num_max, custom_err_msg
+        [Value::Integer(min), Value::Integer(max), Value::String(custom_err_msg)] => {
+            Ok(ValidationArgs {
+                expected_min: *min as u64,
+                expected_max: *max as u64,
+                custom_err_msg: custom_err_msg.borrow_ref().unwrap().to_string(),
+            })
+        }
+        _ => Err("Invalid validation arguments".to_string()),
+    }
+}
+
 /// Creates a new UUID for current iteration
 #[rune::function]
 pub fn uuid(i: i64) -> Uuid {

--- a/src/scripting/mod.rs
+++ b/src/scripting/mod.rs
@@ -93,7 +93,16 @@ fn try_install(
     rune_ctx: &mut rune::Context,
     params: HashMap<String, String>,
 ) -> Result<(), ContextError> {
-    let context_module = init_context_module()?;
+    use alternator::functions;
+    let mut context_module = init_context_module()?;
+    context_module.function_meta(functions::create_table)?;
+    context_module.function_meta(functions::delete_table)?;
+    context_module.function_meta(functions::put)?;
+    context_module.function_meta(functions::get)?;
+    context_module.function_meta(functions::delete)?;
+    context_module.function_meta(functions::update)?;
+    context_module.function_meta(functions::query)?;
+
     let err_module = init_error_module()?;
     let uuid_module = init_uuid_module()?;
     let latte_module = init_latte_module(params)?;

--- a/src/scripting/mod.rs
+++ b/src/scripting/mod.rs
@@ -102,6 +102,7 @@ fn try_install(
     context_module.function_meta(functions::delete)?;
     context_module.function_meta(functions::update)?;
     context_module.function_meta(functions::query)?;
+    context_module.function_meta(functions::scan)?;
 
     let err_module = init_error_module()?;
     let uuid_module = init_uuid_module()?;

--- a/src/scripting/row_distribution.rs
+++ b/src/scripting/row_distribution.rs
@@ -516,6 +516,7 @@ mod tests {
             None, 0,
             RetryInterval::new("1,2").expect("failed to parse retry interval"),
             ValidationStrategy::Ignore,
+            0,
         )
     }
 

--- a/workloads/alternator/api_demo.rn
+++ b/workloads/alternator/api_demo.rn
@@ -1,0 +1,69 @@
+use latte::*;
+
+// Usage:
+// latte schema workloads/alternator/api_demo.rn http://172.17.0.2:8000
+// latte run -d 1 workloads/alternator/api_demo.rn http://172.17.0.2:8000
+
+const TABLE = "api_demo_table";
+
+pub async fn schema(db) {
+    // Drop the table (ignoring errors if it doesn't exist) to ensure we always have the up-to-date schema.
+    db.delete_table(TABLE).await;
+    db.create_table(TABLE, #{
+        primary_key: "pk",
+        sort_key: #{name: "sk", type: "N"}
+    }).await?;
+}
+
+// Runs a sequence of operations to verify the API.
+pub async fn run(db, i) {
+    // PUT
+    let user_id = "user_" + i.to_string();
+    let user_order = 1;
+    db.put(TABLE, #{
+        pk: user_id,
+        sk: user_order,
+        name: "Random Name",
+        age: 20,
+        list: ["different", 0, "types"],
+        nested: #{
+            num: 1234567890,
+            bool: true
+        }
+    }).await?;
+
+    // GET
+    let key = #{
+        pk: user_id,
+        sk: user_order
+    };
+    db.get(TABLE, key, None).await?;
+    db.get(TABLE, key, #{
+        consistent_read: true
+    }).await?;
+
+    // UPDATE Item
+    db.update(TABLE, key, #{
+        update: "SET #n = :new_name, age = :new_age",
+        "attribute_names": #{
+            "#n": "name"
+        },
+        "attribute_values": #{
+            ":new_name": "Other name",
+            ":new_age": 21
+        }
+    }).await?;
+
+    // QUERY
+    db.query(TABLE, #{
+        query: "pk = :pk",
+        "attribute_values": #{
+            ":pk": user_id
+        },
+        limit: 1,
+        consistent_read: true
+    }).await?;
+
+    // DELETE Item
+    db.delete(TABLE, key).await?;
+}

--- a/workloads/alternator/api_demo.rn
+++ b/workloads/alternator/api_demo.rn
@@ -64,6 +64,15 @@ pub async fn run(db, i) {
         consistent_read: true
     }).await?;
 
+    // QUERY with validation
+    db.query(TABLE, #{
+        query: "pk = :pk",
+        "attribute_values": #{
+            ":pk": user_id
+        },
+        validation: [1]
+    }).await?;
+
     // DELETE Item
     db.delete(TABLE, key).await?;
 }

--- a/workloads/alternator/api_demo.rn
+++ b/workloads/alternator/api_demo.rn
@@ -73,6 +73,14 @@ pub async fn run(db, i) {
         validation: [1]
     }).await?;
 
+    // SCAN
+    db.scan(TABLE, #{
+        filter: "age > :min_age",
+        "attribute_values": #{
+            ":min_age": 18
+        }
+    }).await?;
+
     // DELETE Item
     db.delete(TABLE, key).await?;
 }

--- a/workloads/alternator/large_objects.rn
+++ b/workloads/alternator/large_objects.rn
@@ -1,0 +1,40 @@
+use latte::*;
+
+// Workload for Alternator that inserts large objects and performs GET operations.
+// Used to test the performance of `with_result`.
+//
+// Usage:
+// latte schema workloads/alternator/large_objects.rn http://172.17.0.2:8000
+// latte run workloads/alternator/large_objects.rn -f insert -d 1000 http://172.17.0.2:8000
+// latte run workloads/alternator/large_objects.rn http://172.17.0.2:8000
+// latte run workloads/alternator/large_objects.rn http://172.17.0.2:8000 -P with_result=true
+
+const TABLE = "large_objects_table";
+const ROW_COUNT = latte::param!("rows", 1000);
+const OBJECT_SIZE = latte::param!("size", 10240); // 10 KB by default
+const WITH_RESULT = latte::param!("with_result", false);
+
+pub async fn schema(db) {
+    // Drop the table (ignoring errors if it doesn't exist) to ensure we always have the up-to-date schema.
+    db.delete_table(TABLE).await;
+    db.create_table(TABLE, "id").await?;
+}
+
+pub async fn insert(db, i) {
+    let id = i % ROW_COUNT;
+
+    db.put(TABLE, #{
+        id: id.to_string(),
+        data: latte::text(i, OBJECT_SIZE)
+    }).await?;
+}
+
+pub async fn run(db, i) {
+    let id = (latte::hash(i) % ROW_COUNT).to_string();
+    let key = #{ id: id };
+    if WITH_RESULT {
+        db.get(TABLE, key, #{ with_result: true }).await?;
+    } else {
+        db.get(TABLE, key, ()).await?;
+    }
+}

--- a/workloads/alternator/row_count_validation.rn
+++ b/workloads/alternator/row_count_validation.rn
@@ -1,0 +1,63 @@
+use latte::*;
+
+// Usage:
+// latte schema workloads/alternator/row_count_validation.rn http://172.17.0.2:8000
+// latte run workloads/alternator/row_count_validation.rn -d 1000 -f insert http://172.17.0.2:8000
+// latte run workloads/alternator/row_count_validation.rn -d 1000 -f query http://172.17.0.2:8000
+// latte run workloads/alternator/row_count_validation.rn -d 1000 -f query_many http://172.17.0.2:8000
+
+const ROW_COUNT = latte::param!("row_count", 1000);
+const ROWS_PER_PARTITION = latte::param!("rows_per_partition", 1);
+// NOTE: 'partition_sizes' defines set of 'percent:multiplier' pairs to create multi-row partitions
+// of different sizes. Example: '95:1,4:2,1:4'
+const PARTITION_SIZES = latte::param!("partition_sizes", "50:4,50:6");
+
+const TABLE = "row_count_validation_table";
+
+pub async fn schema(db) {
+    // Drop the table (ignoring errors if it doesn't exist) to ensure we always have the up-to-date schema.
+    db.delete_table(TABLE).await;
+    db.create_table(TABLE, #{primary_key: #{name: "pk", type: "N"}, sort_key: #{name: "ck", type: "N"}}).await?;
+}
+
+pub async fn prepare(db) {
+    db.init_partition_row_distribution_preset("main", ROW_COUNT, ROWS_PER_PARTITION, PARTITION_SIZES).await?;
+}
+
+pub async fn insert(db, i) {
+    let idx = i % ROW_COUNT;
+    let partition = db.get_partition_info("main", idx).await;
+    let pk = hash(partition.idx);
+    let ck = hash(idx);
+    
+    db.put(TABLE, #{pk: pk, ck: ck}).await?;
+}
+
+pub async fn query(db, i) {
+    let idx = i % ROW_COUNT;
+    let partition = db.get_partition_info("main", idx).await;
+    let pk = hash(partition.idx);
+
+    db.query(TABLE, #{
+        query: "pk = :pk",
+        "attribute_values": #{
+            ":pk": pk
+        },
+        limit: 1,
+        validation: [1, "custom error"]
+    }).await?;
+}
+
+pub async fn query_many(db, i) {
+    let idx = i % ROW_COUNT;
+    let partition = db.get_partition_info("main", idx).await;
+    let pk = hash(partition.idx);
+
+    db.query(TABLE, #{
+        query: "pk = :pk",
+        attribute_values: #{
+            ":pk": pk
+        },
+        validation: [partition.rows_num, partition.rows_num]
+    }).await?;
+}

--- a/workloads/alternator/type_validation.rn
+++ b/workloads/alternator/type_validation.rn
@@ -13,8 +13,10 @@ pub async fn schema(db) {
 }
 
 pub async fn run(db, i) {
+    let pk = "item_" + i.to_string();
+    
     let item = #{
-        pk: "item_" + i.to_string(),
+        pk: pk,
         
         // Boolean "AttributeValue::Bool"
         bool_true: true,
@@ -56,4 +58,49 @@ pub async fn run(db, i) {
     };
 
     db.put(TABLE, item).await?;
+    
+    // Retrieve the item and validate types
+    let result = db.get(TABLE, #{ pk: pk }, #{
+        with_result: true
+    }).await?.unwrap();
+
+    // The same can be achieved using query
+    // let result = db.query(TABLE, #{
+    //     query: "pk = :pk",
+    //     "attribute_values": #{
+    //         ":pk": pk
+    //     },
+    //     with_result: true
+    // }).await?[0];
+
+    assert!(result["bool_true"] == true);
+    assert!(result["bool_false"] == false);
+
+    assert!(result["integer"] == 42);
+    assert!(result["float"] is f64);
+    
+    assert!(result["test_string"] == "Hello, World!");
+
+    assert!(result["test_bytes"] ==  b"binary data");
+
+    assert!(result["test_list"] == [
+        1, 
+        "two", 
+        3.0, 
+        true, 
+        [1, 2], 
+        #{ key: "value" }
+    ]);
+    assert!(result["test_empty_list"] == []);
+
+    assert!(result["test_map"] == #{
+        nested_string: "nested",
+        nested_int: 100,
+        deep_nesting: #{
+            level: 2
+        }
+    });
+    
+    assert!(result["test_option_some"] == 42);
+    assert!(result["test_option_none"] == None);
 }

--- a/workloads/alternator/type_validation.rn
+++ b/workloads/alternator/type_validation.rn
@@ -1,0 +1,59 @@
+use latte::*;
+
+// Usage:
+// latte schema workloads/alternator/type_validation.rn http://172.17.0.2:8000
+// latte run -d 1 workloads/alternator/type_validation.rn http://172.17.0.2:8000
+
+const TABLE = "type_validation_table";
+
+pub async fn schema(db) {
+    // Drop the table (ignoring errors if it doesn't exist) to ensure we always have the up-to-date schema.
+    db.delete_table(TABLE).await;
+    db.create_table(TABLE, "pk").await?;
+}
+
+pub async fn run(db, i) {
+    let item = #{
+        pk: "item_" + i.to_string(),
+        
+        // Boolean "AttributeValue::Bool"
+        bool_true: true,
+        bool_false: false,
+        
+        // Numbers "AttributeValue::N"
+        integer: 42,
+        float: 1.23,
+        
+        // String "AttributeValue::S"
+        test_string: "Hello, World!",
+        
+        // Binary "AttributeValue::B"
+        test_bytes: b"binary data",
+        
+        // List "AttributeValue::L"
+        test_list: [
+            1, 
+            "two", 
+            3.0, 
+            true, 
+            [1, 2], 
+            #{ key: "value" }
+        ],
+        test_empty_list: [],
+        
+        // Map "AttributeValue::M"
+        test_map: #{
+            nested_string: "nested",
+            nested_int: 100,
+            deep_nesting: #{
+                level: 2
+            }
+        },
+        
+        // Option - If Some, serialize the inner value; if None, serialize as Null
+        test_option_some: Some(42),
+        test_option_none: None,
+    };
+
+    db.put(TABLE, item).await?;
+}


### PR DESCRIPTION
This pull request implements Alternator API. In previous PR #122 we added "latte for Alternator" skeleton, which now is filled with logic for actual Alternator calls.
Implemented are CreateTable, DeleteTable, PutItem, GetItem, DeleteItem, UpdateItem, Query, Scan.
Example and test workloads are given in `workloads/alternator`.

**DynamoDB request and output abstraction:**

* Introduced new traits (`SendRequest`, `AlternatorRequest`, `IntoAlternatorOutput`) to abstract request sending and output conversion for DynamoDB operations, including pagination support and macro-based implementations for various request types. (`src/scripting/alternator/traits.rs`)

**Rune and DynamoDB value conversion utilities:**

* Added functions for converting between Rune values and DynamoDB attribute values, including support for all major types and error handling for unsupported conversions. (`src/scripting/alternator/types.rs`)

**Context and cluster metadata improvements:**

* Added `page_size` to `Context`, ensured it is serialized/deserialized, and implemented methods to retrieve the client and page size. The `cluster_info` method now detects ScyllaDB and AWS DynamoDB clusters by querying system tables and endpoints. (`src/scripting/alternator/context.rs`)

**Error handling enhancements:**

* Expanded `AlternatorErrorKind` to include new error variants (`SdkError`, `BadInput`, `ConversionError`, `ValidationError`) and implemented conversions from various error types for improved error reporting and interoperability. (`src/scripting/alternator/alternator_error.rs`)

**Build and test infrastructure updates:**

* Updated `Cargo.toml` and `Makefile` to support Alternator-specific binaries and build/test targets, enabling feature-specific compilation and testing. (`Cargo.toml`, `Makefile`) 

Follow-up #122 
