### PR TITLE
build: bump rust toolchain from `1.90` to `1.94`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.90-slim-trixie AS builder
+FROM rust:1.94-slim-trixie AS builder
 
 WORKDIR /usr/src/app
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.90"
+channel = "1.94"
 components = ["clippy", "rustfmt", "cargo"]

--- a/src/exec/mod.rs
+++ b/src/exec/mod.rs
@@ -12,7 +12,6 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 use std::time::{Duration, Instant};
-use tokio::pin;
 use tokio::signal::ctrl_c;
 
 use crate::error::{LatteError, Result};


### PR DESCRIPTION
Our tests have been failing the following way for quite some time:

```
Run baptiste0928/cargo-install@v3
Installing cargo-nextest...
No cached version found, installing cargo-nextest using cargo...
  /home/runner/.cargo/bin/cargo install cargo-nextest --force --root /home/runner/.cargo-install/cargo-nextest --version 0.9.132 --locked
      Updating crates.io index
   Downloading crates ...
    Downloaded cargo-nextest v0.9.132
  error: cannot install package `cargo-nextest 0.9.132`, it requires rustc 1.91 or newer, while the currently active rustc version is 1.90.0
  `cargo-nextest 0.9.128` supports rustc 1.89
  Error: The process '/home/runner/.cargo/bin/cargo' failed with exit code 101
  Error: The process '/home/runner/.cargo/bin/cargo' failed with exit code 101
      at _ExecState._setResult (/home/runner/work/_actions/baptiste0928/cargo-install/v3/dist/index.js:28635:18)
      at _ExecState.CheckComplete (/home/runner/work/_actions/baptiste0928/cargo-install/v3/dist/index.js:28621:12)
      at ChildProcess.<anonymous> (/home/runner/work/_actions/baptiste0928/cargo-install/v3/dist/index.js:28526:18)
      at ChildProcess.emit (node:events:508:28)
      at maybeClose (node:internal/child_process:1100:16)
      at ChildProcess._handle.onexit (node:internal/child_process:305:5)
```

So, bump the rust toolchain to a newer stable version.