### PR TITLE
chore(renovate): bump Cargo.toml versions alongside Cargo.lock

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -15,6 +15,9 @@
     "github-actions",
     "helm-values"
   ],
+  "cargo": {
+    "rangeStrategy": "bump"
+  },
   "packageRules": [
     {
       "groupName": "All dependencies",


### PR DESCRIPTION
## Summary

- Adds `"rangeStrategy": "bump"` for the cargo manager in `renovate.json`

## Problem

Currently Renovate only updates `Cargo.lock` for patch/minor dependency updates (e.g. [4eb6212](https://github.com/scylladb/latte/commit/4eb6212af17f221eee7207d1c8397dab9b296ebd)). This happens because `Cargo.toml` uses loose constraints like `"0.10"` which already satisfy the new version — so Renovate sees no reason to touch it.

This makes it hard to tell from `Cargo.toml` what version is actually in use.

## Fix

Setting `rangeStrategy` to `"bump"` instructs Renovate to also bump the version string in `Cargo.toml` to the new exact minor/patch version, even when the existing constraint already allows it.

For example, if `openssl` is `"0.10"` in Cargo.toml and Renovate wants to update to `0.10.79`, it will now change the constraint to `"0.10.79"` (or the appropriate bumped range).

See: https://docs.renovatebot.com/configuration-options/#rangestrategy