### PR TITLE
Fix the `workloads/alternator/type_validation.rn`

### DIFF
--- a/workloads/alternator/type_validation.rn
+++ b/workloads/alternator/type_validation.rn
@@ -68,9 +68,14 @@ pub async fn run(db, i) {
     db.put(TABLE, item).await?;
     
     // Retrieve the item and validate types
-    let result = db.get(TABLE, #{ pk: pk }, #{
-        with_result: true
-    }).await?.unwrap();
+    let result_wrapped = db.get(TABLE, #{ pk: pk }, #{
+        with_result: true,
+        consistent_read: true
+    }).await?;
+    if is_none(result_wrapped) {
+        db.signal_failure(`Expected item with pk='${pk}' to exist, but got 'None'`).await?;
+    }
+    let result = result_wrapped.unwrap();
 
     // The same can be achieved using query
     // let result = db.query(TABLE, #{


### PR DESCRIPTION
It may fail with the following error:
```
    error: Panicked: Called `Option::unwrap()` on a `None` value
       ┌─ /home/runner/work/latte/latte/workloads/alternator/type_validation.rn:71:18
       │
    71 │       let result = db.get(TABLE, #{ pk: pk }, #{
       │ ╭──────────────────^
    72 │ │         with_result: true
    73 │ │     }).await?.unwrap();
       │ ╰──────────────────────^ Panicked: Called `Option::unwrap()` on a `None` value
```

So, fix it by doing 2 following changes:
- Use the `consistent_read: true` flag for the query
- Properly handle the `None` cases in this place