### PR TITLE
Switch rune to fork with compiler divergence fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3273,8 +3273,7 @@ dependencies = [
 [[package]]
 name = "rune"
 version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7b9174512d64882469ea9b12876305680154a541be448dcdc56f58acacbc3e0"
+source = "git+https://github.com/vponomaryov/rune.git?branch=fix-return-0.14.x#1eaa8a2dd50cd229f3c2eb94c6d74fb5bfb7dc07"
 dependencies = [
  "anyhow",
  "codespan-reporting",
@@ -3299,8 +3298,7 @@ dependencies = [
 [[package]]
 name = "rune-alloc"
 version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f12484a608c8907b9a4590f11b669263e960d1fd40f3d3c992c6f15eec931ae9"
+source = "git+https://github.com/vponomaryov/rune.git?branch=fix-return-0.14.x#1eaa8a2dd50cd229f3c2eb94c6d74fb5bfb7dc07"
 dependencies = [
  "ahash 0.8.12",
  "pin-project",
@@ -3311,8 +3309,7 @@ dependencies = [
 [[package]]
 name = "rune-alloc-macros"
 version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "382b14f6d8e65e9cfec789e85125f3e1d758b2756705739e39ccf06fd249a564"
+source = "git+https://github.com/vponomaryov/rune.git?branch=fix-return-0.14.x#1eaa8a2dd50cd229f3c2eb94c6d74fb5bfb7dc07"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3322,8 +3319,7 @@ dependencies = [
 [[package]]
 name = "rune-core"
 version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c424b28fde0f5012680361662145f238f04aeac8a320f352a6e2de863709e7b3"
+source = "git+https://github.com/vponomaryov/rune.git?branch=fix-return-0.14.x#1eaa8a2dd50cd229f3c2eb94c6d74fb5bfb7dc07"
 dependencies = [
  "musli",
  "rune-alloc",
@@ -3334,8 +3330,7 @@ dependencies = [
 [[package]]
 name = "rune-macros"
 version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c86600b36281adeb101c2e4f0be325752fa4c07431e9234e05be5678ad9a97f7"
+source = "git+https://github.com/vponomaryov/rune.git?branch=fix-return-0.14.x#1eaa8a2dd50cd229f3c2eb94c6d74fb5bfb7dc07"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3346,8 +3341,7 @@ dependencies = [
 [[package]]
 name = "rune-tracing"
 version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0717a7c726015688a19ebfa4bea03a20d2acdd96eeacb5ef48f4ec780e11ac4b"
+source = "git+https://github.com/vponomaryov/rune.git?branch=fix-return-0.14.x#1eaa8a2dd50cd229f3c2eb94c6d74fb5bfb7dc07"
 dependencies = [
  "rune-tracing-macros",
 ]
@@ -3355,8 +3349,7 @@ dependencies = [
 [[package]]
 name = "rune-tracing-macros"
 version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12387f96a3e131ce5be8c5668e55f1581dbc6635555d77aa07ab509fd13562bb"
+source = "git+https://github.com/vponomaryov/rune.git?branch=fix-return-0.14.x#1eaa8a2dd50cd229f3c2eb94c6d74fb5bfb7dc07"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ plotters = { version = "0.3", default-features = false, features = ["line_series
 rand = { version = "0.9.4", default-features = false, features = ["small_rng", "std", "thread_rng"] }
 rand_distr = "0.5"
 regex = "1.5"
-rune = "0.14"
+rune = { git = "https://github.com/vponomaryov/rune.git", branch = "fix-return-0.14.x" }
 rust_decimal = "1.36"
 rust-embed = "8"
 scylla = { version = "1.6", features = ["openssl-010", "chrono-04"], optional = true }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -316,3 +316,30 @@ async fn test_latte_alternator_type_validation_workload() {
     assert_latte_success(&result);
     assert_has_throughput_metrics(&result);
 }
+
+/// Tests that `return` inside if/else and match arms in async functions
+/// compiles and executes correctly. This directly exercises the rune compiler
+/// divergence fix for both expr_if and expr_match
+/// Ref: https://github.com/rune-rs/rune/issues/1016
+#[tokio::test]
+#[ignore]
+async fn test_rune_return_in_diverging_branches() {
+    let db = start_scylla().await.expect("Failed to start ScyllaDB");
+
+    let latte = LatteVariant::Cql;
+    let workload = workload_path("integration_tests/return_statement.rn");
+    let duration = "5000";
+
+    println!("\n[TEST-INFO] Phase 1: Create the schema ({:?})", latte);
+    latte.schema(&db, &workload, &[]);
+
+    println!("\n[TEST-INFO] Phase 2: Write (exercises return in if/else and match)");
+    let write_result = latte.run(&db, &workload, duration, &["-f", "write"]);
+    assert_latte_success(&write_result);
+    assert_has_throughput_metrics(&write_result);
+
+    println!("\n[TEST-INFO] Phase 3: Read (exercises return in if/else)");
+    let read_result = latte.run(&db, &workload, duration, &["-f", "read"]);
+    assert_latte_success(&read_result);
+    assert_has_throughput_metrics(&read_result);
+}

--- a/workloads/integration_tests/return_statement.rn
+++ b/workloads/integration_tests/return_statement.rn
@@ -1,0 +1,54 @@
+use latte::*;
+
+const KEYSPACE = "ks_return_divergence";
+const TABLE = "t_return_divergence";
+const ROW_COUNT = 5000;
+
+pub async fn schema(db) {
+    db.execute(`CREATE KEYSPACE IF NOT EXISTS ${KEYSPACE}
+        WITH REPLICATION = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}
+        AND durable_writes = true`).await?;
+    db.execute(`CREATE TABLE IF NOT EXISTS ${KEYSPACE}.${TABLE} (
+        pk int PRIMARY KEY, val text
+    )`).await?;
+}
+
+pub async fn prepare(db) {
+    db.prepare("insert", `INSERT INTO ${KEYSPACE}.${TABLE} (pk, val) VALUES (:pk, :val)`).await?;
+    db.prepare("select", `SELECT * FROM ${KEYSPACE}.${TABLE} WHERE pk = :pk`).await?;
+}
+
+/// return inside if/else — both branches diverge
+async fn get_idx(i, flag) {
+    if flag > 0 {
+        return i % ROW_COUNT;
+    } else {
+        return (i + 50) % ROW_COUNT;
+    }
+}
+
+/// return inside match — all arms diverge
+async fn get_value(db, idx) {
+    match idx % 3 {
+        0 => {
+            return "zero"
+        },
+        1 => {
+            return "one"
+        },
+        _ => {
+            return "other"
+        }
+    }
+}
+
+pub async fn write(db, i) {
+    let idx = get_idx(i, i % 2).await;
+    let val = get_value(db, idx).await;
+    db.execute_prepared("insert", [idx, val]).await?;
+}
+
+pub async fn read(db, i) {
+    let idx = get_idx(i, i % 2).await;
+    db.execute_prepared("select", [idx]).await?;
+}


### PR DESCRIPTION
Use `vponomaryov/rune fix-return-0.14.x` branch which fixes the `No address for need defer(0:0 (return value))` compiler error that occurred when `return` was used inside `if/else` or `match` arms in `async` functions.

The fork applies two fixes on top of rune 0.14.1:
- Propagate divergence from expr_match when all arms diverge
- Propagate divergence from expr_if when all branches diverge

Fixes: #168