### PR TITLE
chore(deps): update openssl to `0.10.80`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2567,9 +2567,9 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openssl"
-version = "0.10.79"
+version = "0.10.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf0b434746ee2832f4f0baf10137e1cabb18cbe6912c69e2e33263c45250f542"
+checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -2598,9 +2598,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.115"
+version = "0.9.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "158fe5b292746440aa6e7a7e690e55aeb72d41505e2804c23c6973ad0e9c9781"
+checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ metrohash = "1.0"
 more-asserts = "0.3"
 num_cpus = "1.13.0"
 once_cell = "1.21"
-openssl = "0.10.78"
+openssl = "0.10.80"
 humantime = "2"
 pin-project = "1.1"
 plotters = { version = "0.3", default-features = false, features = ["line_series", "svg_backend", "full_palette"] }


### PR DESCRIPTION
It is replacement PR for the renovate's one: https://github.com/scylladb/latte/pull/170
`Reason`: it doesn't update the `Cargo.toml` as of now