### PR TITLE
chore(deps): update rune to `0.14.2`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3272,8 +3272,9 @@ dependencies = [
 
 [[package]]
 name = "rune"
-version = "0.14.1"
-source = "git+https://github.com/vponomaryov/rune.git?branch=fix-return-0.14.x#1eaa8a2dd50cd229f3c2eb94c6d74fb5bfb7dc07"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7a577a0dc4b3e4cfe89247325b14b5f30096ddc82fa51fffb1d823fbc85b410"
 dependencies = [
  "anyhow",
  "codespan-reporting",
@@ -3297,8 +3298,9 @@ dependencies = [
 
 [[package]]
 name = "rune-alloc"
-version = "0.14.1"
-source = "git+https://github.com/vponomaryov/rune.git?branch=fix-return-0.14.x#1eaa8a2dd50cd229f3c2eb94c6d74fb5bfb7dc07"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "702abcb136e7e4ff61c29006f018ab535728388b950bfbd50a0a66d7a2db1ff6"
 dependencies = [
  "ahash 0.8.12",
  "pin-project",
@@ -3308,8 +3310,9 @@ dependencies = [
 
 [[package]]
 name = "rune-alloc-macros"
-version = "0.14.1"
-source = "git+https://github.com/vponomaryov/rune.git?branch=fix-return-0.14.x#1eaa8a2dd50cd229f3c2eb94c6d74fb5bfb7dc07"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98fa2ddc4ebb390a257f05659081e5f4a1419ca65f0c7a3f4b02547860dd93f4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3318,8 +3321,9 @@ dependencies = [
 
 [[package]]
 name = "rune-core"
-version = "0.14.1"
-source = "git+https://github.com/vponomaryov/rune.git?branch=fix-return-0.14.x#1eaa8a2dd50cd229f3c2eb94c6d74fb5bfb7dc07"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fab02420e2189ad2d8d9efceca5319782873eb547c61b68732746cc161547aa"
 dependencies = [
  "musli",
  "rune-alloc",
@@ -3329,8 +3333,9 @@ dependencies = [
 
 [[package]]
 name = "rune-macros"
-version = "0.14.1"
-source = "git+https://github.com/vponomaryov/rune.git?branch=fix-return-0.14.x#1eaa8a2dd50cd229f3c2eb94c6d74fb5bfb7dc07"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d314f34d8b30569189d90ac0f96eeedf629492c10d18146b40cfb76bd3fd2d52"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3340,16 +3345,18 @@ dependencies = [
 
 [[package]]
 name = "rune-tracing"
-version = "0.14.1"
-source = "git+https://github.com/vponomaryov/rune.git?branch=fix-return-0.14.x#1eaa8a2dd50cd229f3c2eb94c6d74fb5bfb7dc07"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5b903935dfcb0ab9eec395f4c2e04b174448bb8d1fd35ef5181ad67140239a9"
 dependencies = [
  "rune-tracing-macros",
 ]
 
 [[package]]
 name = "rune-tracing-macros"
-version = "0.14.1"
-source = "git+https://github.com/vponomaryov/rune.git?branch=fix-return-0.14.x#1eaa8a2dd50cd229f3c2eb94c6d74fb5bfb7dc07"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75193c702bddd8a5b74b1f9a5a992cef3c6b2df2909d6f0bb0f4b0f3ec8a2f66"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ plotters = { version = "0.3", default-features = false, features = ["line_series
 rand = { version = "0.9.4", default-features = false, features = ["small_rng", "std", "thread_rng"] }
 rand_distr = "0.5"
 regex = "1.5"
-rune = { git = "https://github.com/vponomaryov/rune.git", branch = "fix-return-0.14.x" }
+rune = "0.14.2"
 rust_decimal = "1.36"
 rust-embed = "8"
 scylla = { version = "1.6", features = ["openssl-010", "chrono-04"], optional = true }


### PR DESCRIPTION
The fix for the `return` statement compilation bug [1] was merged to the rune library [2] and released [3].

So, switch to this official rune version instead of the own fork.

[1] https://github.com/scylladb/latte/issues/168
[2] https://github.com/rune-rs/rune/pull/1019
[3] https://github.com/rune-rs/rune/releases/tag/0.14.2