### PR TITLE
improvement(ci): Add version verification gate to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,30 @@ env:
   RUSTFLAGS: "--cfg fetch_extended_version_info --cfg tokio_unstable"
 
 jobs:
+  verify_version:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Verify tag matches Cargo.toml version
+        run: |
+          CARGO_VERSION=$(grep '^version' Cargo.toml | head -1 | sed 's/.*"\(.*\)"/\1/')
+          TAG="${GITHUB_REF_NAME}"
+          if [[ "$TAG" != "$CARGO_VERSION" ]]; then
+            echo "::error::Tag '$TAG' does not match Cargo.toml version '$CARGO_VERSION'"
+            exit 1
+          fi
+      - name: Verify release does not already exist
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+          if gh release view "$TAG" &>/dev/null; then
+            echo "::error::Release '$TAG' already exists"
+            exit 1
+          fi
+
   get_tag:
+    needs: [verify_version]
     runs-on: ubuntu-latest
     outputs:
       tag: ${{ steps.version_tag.outputs.tag }}
@@ -27,6 +50,7 @@ jobs:
           tagRegex: "(.*)"
 
   release:
+    needs: [verify_version]
     runs-on: ubuntu-24.04
     permissions:
       contents: write


### PR DESCRIPTION
The `0.46.0-scylladb` version was released with non-updated version value.
So, `latte --version` returns there previous/wrong result.

Avoid such mistakes for future releases by adding a preliminary gate
by matching the current version to the tag and release configured for a build.

Make all other CI jobs depend on it.