### PR TITLE
chore(deps): update `astral-tokio-tar` to `0.6.2` (security fix)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,9 +140,9 @@ checksum = "3c07dab4369547dbe5114677b33fbbf724971019f3818172d59a97a61c774ffd"
 
 [[package]]
 name = "astral-tokio-tar"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c23f3af104b40a3430ccb90ed5f7bd877a8dc5c26fc92fde51a22b40890dcf9"
+checksum = "cb50a7aae84a03bf55b067832bc376f4961b790c97e64d3eacee97d389b90277"
 dependencies = [
  "filetime",
  "futures-core",


### PR DESCRIPTION
Fixes PAX header desynchronization vulnerability
that allows manipulated tar entries to smuggle unexpected files during extraction.

Ref: [GHSA-j5gw-2vrg-8fgx](https://github.com/advisories/GHSA-j5gw-2vrg-8fgx)