### PR TITLE
Fix latte show failing on reports generated by latte itself

### DIFF
--- a/src/scripting/alternator/config.rs
+++ b/src/scripting/alternator/config.rs
@@ -13,7 +13,7 @@ pub struct DbConnectionConf {
     pub access_key_id: String,
 
     /// Secret access key.
-    #[serde(skip_serializing)] // Don't save the secret to generated reports.
+    #[serde(skip)] // Keep the secret out of generated reports; defaults to empty when a report is read back.
     #[clap(long("secret-access-key"), default_value = "")]
     pub secret_access_key: String,
 

--- a/src/scripting/cql/config.rs
+++ b/src/scripting/cql/config.rs
@@ -20,7 +20,7 @@ pub struct DbConnectionConf {
     pub user: String,
 
     /// Password to use if password authentication is required by the server
-    #[serde(skip_serializing)] // Don't save the password to generated reports.
+    #[serde(skip)] // Keep the password out of generated reports; defaults to empty when a report is read back.
     #[clap(long, env("CASSANDRA_PASSWORD"), default_value = "")]
     pub password: String,
 


### PR DESCRIPTION
`password` (CQL) and `secret_access_key` (Alternator) are `serde(skip_serializing)` to keep secrets out of generated reports, but deserialization still required them. Every report written with `--generate-report` was unreadable by `latte show`, `latte list` and `-b` baseline comparison.

Use `serde(skip)`: still never serialized, defaulted to empty on read instead of required. Files that do contain the fields are read with them ignored.

Reproduction on main:
```
    RUSTFLAGS="--cfg fetch_extended_version_info --cfg tokio_unstable" cargo build --release
    ./target/release/latte run -d 3s --generate-report -o /tmp/r.json workloads/basic/empty.rn <node>
    ./target/release/latte show /tmp/r.json
    # error: Failed to read report from /tmp/r.json: missing field `password` at line 75 column 5
```

Introduced in #158.