### PR TITLE
Add unit tests for the hidden passwords from reports

### DIFF
--- a/src/scripting/alternator/config.rs
+++ b/src/scripting/alternator/config.rs
@@ -21,3 +21,34 @@ pub struct DbConnectionConf {
     #[clap(long("region"), default_value = "us-east-1")]
     pub region: String,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deserialize_without_secret_access_key_field() {
+        // Simulates reading a report generated with serde(skip): the secret field is absent.
+        let json = r#"{
+            "aws_credentials": false,
+            "access_key_id": "",
+            "region": "us-east-1"
+        }"#;
+        let conf: DbConnectionConf = serde_json::from_str(json).unwrap();
+        assert_eq!(conf.secret_access_key, "");
+    }
+
+    #[test]
+    fn deserialize_with_secret_access_key_field_ignores_it() {
+        // Backwards compatibility: if an older report contains the secret field,
+        // deserialization still succeeds and the value is defaulted.
+        let json = r#"{
+            "aws_credentials": false,
+            "access_key_id": "",
+            "secret_access_key": "supersecret",
+            "region": "us-east-1"
+        }"#;
+        let conf: DbConnectionConf = serde_json::from_str(json).unwrap();
+        assert_eq!(conf.secret_access_key, "");
+    }
+}

--- a/src/scripting/cql/config.rs
+++ b/src/scripting/cql/config.rs
@@ -190,3 +190,43 @@ impl ValueEnum for SerialConsistency {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deserialize_without_password_field() {
+        // Simulates reading a report that was generated with skip_serializing/skip:
+        // the password field is absent from JSON.
+        let json = r#"{
+            "count": 1,
+            "user": "",
+            "ssl": false,
+            "ssl_peer_verification": false,
+            "consistency": "LocalQuorum",
+            "serial_consistency": "LocalSerial"
+        }"#;
+        let conf: DbConnectionConf = serde_json::from_str(json).unwrap();
+        assert_eq!(conf.password, "");
+    }
+
+    #[test]
+    fn deserialize_with_password_field_ignores_it() {
+        // Backwards compatibility: if an older report somehow contains the password field,
+        // deserialization should still succeed (serde(skip) ignores unknown/skipped fields
+        // when deny_unknown_fields is not set).
+        let json = r#"{
+            "count": 1,
+            "user": "",
+            "password": "secret123",
+            "ssl": false,
+            "ssl_peer_verification": false,
+            "consistency": "LocalQuorum",
+            "serial_consistency": "LocalSerial"
+        }"#;
+        let conf: DbConnectionConf = serde_json::from_str(json).unwrap();
+        // serde(skip) means the field is always defaulted, even if present in input
+        assert_eq!(conf.password, "");
+    }
+}


### PR DESCRIPTION
It is follow-up for the following merged fix:

Ref: https://github.com/scylladb/latte/pull/181