### PR TITLE
Add custom metrics and report metadata recording for workload scripts

### DIFF
--- a/src/exec/mod.rs
+++ b/src/exec/mod.rs
@@ -342,7 +342,8 @@ pub async fn par_execute(
         let partial_stats = receive_one_of_each(&mut streams).await;
         let partial_stats: Vec<_> = partial_stats.into_iter().try_collect()?;
         if partial_stats.is_empty() {
-            break Ok(stats.finish());
+            let run_metadata = workload.context().report_metadata_snapshot();
+            break Ok(stats.finish(run_metadata));
         }
 
         let aggregate = stats.record(&partial_stats);

--- a/src/exec/mod.rs
+++ b/src/exec/mod.rs
@@ -342,8 +342,11 @@ pub async fn par_execute(
         let partial_stats = receive_one_of_each(&mut streams).await;
         let partial_stats: Vec<_> = partial_stats.into_iter().try_collect()?;
         if partial_stats.is_empty() {
-            let run_metadata = workload.context().report_metadata_snapshot();
-            break Ok(stats.finish(run_metadata));
+            let context = workload.context();
+            break Ok(stats.finish(
+                context.report_metadata_snapshot(),
+                context.metric_orientations_snapshot(),
+            ));
         }
 
         let aggregate = stats.record(&partial_stats);

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -820,19 +820,32 @@ impl Display for BenchmarkCmp<'_> {
                 writeln!(f, "{}", fmt_cmp_header(true))?;
             }
 
-            let l = self.line("Mean", "", |s| {
-                Quantity::from(s.custom_metrics.get(name).map(|m| m.distribution.mean))
-                    .with_precision(4)
-            });
+            let orientation = self
+                .v1
+                .custom_metrics
+                .get(name)
+                .or_else(|| self.v2.and_then(|v2| v2.custom_metrics.get(name)))
+                .map(|m| m.orientation)
+                .unwrap_or(0);
+            let l = self
+                .line("Mean", "", |s| {
+                    Quantity::from(s.custom_metrics.get(name).map(|m| m.distribution.mean))
+                        .with_precision(4)
+                })
+                .with_significance(self.cmp_mean_custom_metric(name))
+                .with_orientation(orientation);
             writeln!(f, "{l}")?;
             for p in resp_time_percentiles.iter() {
-                let l = self.line(p.name(), "", |s| {
-                    let v = s
-                        .custom_metrics
-                        .get(name)
-                        .map(|m| m.distribution.percentiles.get(*p));
-                    Quantity::from(v).with_precision(4)
-                });
+                let l = self
+                    .line(p.name(), "", |s| {
+                        let v = s
+                            .custom_metrics
+                            .get(name)
+                            .map(|m| m.distribution.percentiles.get(*p));
+                        Quantity::from(v).with_precision(4)
+                    })
+                    .with_significance(self.cmp_custom_metric_percentile(name, *p))
+                    .with_orientation(orientation);
                 writeln!(f, "{l}")?;
             }
         }

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -802,6 +802,41 @@ impl Display for BenchmarkCmp<'_> {
             }
         }
 
+        let metric_names = self
+            .v1
+            .custom_metrics
+            .keys()
+            .chain(self.v2.iter().flat_map(|v2| v2.custom_metrics.keys()))
+            .sorted()
+            .dedup();
+        for name in metric_names {
+            writeln!(f)?;
+            writeln!(
+                f,
+                "{}",
+                fmt_section_header(format!("CUSTOM METRIC {name} ").as_str())
+            )?;
+            if self.v2.is_some() {
+                writeln!(f, "{}", fmt_cmp_header(true))?;
+            }
+
+            let l = self.line("Mean", "", |s| {
+                Quantity::from(s.custom_metrics.get(name).map(|m| m.distribution.mean))
+                    .with_precision(4)
+            });
+            writeln!(f, "{l}")?;
+            for p in resp_time_percentiles.iter() {
+                let l = self.line(p.name(), "", |s| {
+                    let v = s
+                        .custom_metrics
+                        .get(name)
+                        .map(|m| m.distribution.percentiles.get(*p));
+                    Quantity::from(v).with_precision(4)
+                });
+                writeln!(f, "{l}")?;
+            }
+        }
+
         if self.v1.error_count > 0 {
             writeln!(f)?;
             writeln!(f, "{}", fmt_section_header("ERRORS"))?;

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -668,6 +668,27 @@ impl BenchmarkCmp<'_> {
 /// Formats all benchmark stats
 impl Display for BenchmarkCmp<'_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        if !self.v1.run_metadata.is_empty() {
+            writeln!(f, "{}", fmt_section_header("RUN METADATA"))?;
+            if self.v2.is_some() {
+                writeln!(f, "{}", fmt_cmp_header(true))?;
+            }
+            let keys = self
+                .v1
+                .run_metadata
+                .keys()
+                .chain(self.v2.iter().flat_map(|v2| v2.run_metadata.keys()))
+                .sorted()
+                .dedup();
+            for key in keys {
+                let l = self.line(key, "", |s| {
+                    s.run_metadata.get(key).cloned().unwrap_or_default()
+                });
+                writeln!(f, "{l}")?;
+            }
+            writeln!(f)?;
+        }
+
         writeln!(f, "{}", fmt_section_header("SUMMARY STATS"))?;
         if self.v2.is_some() {
             writeln!(f, "{}", fmt_cmp_header(true))?;

--- a/src/scripting/alternator/context.rs
+++ b/src/scripting/alternator/context.rs
@@ -26,6 +26,10 @@ pub struct Context {
     pub partition_row_presets: Arc<TryLock<HashMap<String, RowDistributionPreset>>>,
     #[rune(get, set, add_assign, copy)]
     pub load_cycle_count: u64,
+    /// True on per-worker deep copies made by [`Context::clone`].
+    /// Run-level state written through such a copy (report metadata, metric
+    /// orientations) is never merged back, so the scripting API rejects those calls.
+    pub is_worker_clone: bool,
     #[rune(get)]
     pub data: Value,
 }
@@ -53,6 +57,7 @@ impl Context {
             validation_strategy,
             partition_row_presets: Arc::new(TryLock::new(HashMap::new())),
             load_cycle_count: 0,
+            is_worker_clone: false,
             data: Value::new(Object::new()).unwrap(),
         }
     }
@@ -78,6 +83,7 @@ impl Context {
                 self.partition_row_presets.try_lock().unwrap().clone(),
             )),
             load_cycle_count: self.load_cycle_count,
+            is_worker_clone: true,
             data: deserialized,
         })
     }
@@ -97,6 +103,7 @@ impl Context {
             validation_strategy: self.validation_strategy,
             partition_row_presets: Arc::clone(&self.partition_row_presets),
             load_cycle_count: self.load_cycle_count,
+            is_worker_clone: self.is_worker_clone,
             data: self.data.clone(),
         }
     }

--- a/src/scripting/alternator/context.rs
+++ b/src/scripting/alternator/context.rs
@@ -18,6 +18,7 @@ pub struct Context {
     page_size: u64,
     pub stats: Arc<TryLock<SessionStats>>,
     pub report_metadata: Arc<TryLock<HashMap<String, String>>>,
+    pub metric_orientations: Arc<TryLock<HashMap<String, i8>>>,
     pub start_time: TryLock<Instant>,
     pub retry_number: u64,
     pub retry_interval: RetryInterval,
@@ -45,6 +46,7 @@ impl Context {
             page_size,
             stats: Arc::new(TryLock::new(SessionStats::new())),
             report_metadata: Arc::new(TryLock::new(HashMap::new())),
+            metric_orientations: Arc::new(TryLock::new(HashMap::new())),
             start_time: TryLock::new(Instant::now()),
             retry_number,
             retry_interval,
@@ -64,6 +66,9 @@ impl Context {
             stats: Arc::new(TryLock::new(SessionStats::default())),
             report_metadata: Arc::new(TryLock::new(
                 self.report_metadata.try_lock().unwrap().clone(),
+            )),
+            metric_orientations: Arc::new(TryLock::new(
+                self.metric_orientations.try_lock().unwrap().clone(),
             )),
             start_time: TryLock::new(*self.start_time.try_lock().unwrap()),
             retry_number: self.retry_number,
@@ -85,6 +90,7 @@ impl Context {
             page_size: self.page_size,
             stats: Arc::clone(&self.stats),
             report_metadata: Arc::clone(&self.report_metadata),
+            metric_orientations: Arc::clone(&self.metric_orientations),
             start_time: TryLock::new(*self.start_time.try_lock().unwrap()),
             retry_number: self.retry_number,
             retry_interval: self.retry_interval,
@@ -158,6 +164,21 @@ impl Context {
 
     pub fn report_metadata_snapshot(&self) -> HashMap<String, String> {
         self.report_metadata.try_lock().unwrap().clone()
+    }
+
+    pub fn record_metric(&self, name: &str, value: f64) {
+        self.stats.try_lock().unwrap().record_metric(name, value);
+    }
+
+    pub fn declare_metric(&self, name: &str, orientation: i8) {
+        self.metric_orientations
+            .try_lock()
+            .unwrap()
+            .insert(name.to_string(), orientation);
+    }
+
+    pub fn metric_orientations_snapshot(&self) -> HashMap<String, i8> {
+        self.metric_orientations.try_lock().unwrap().clone()
     }
 
     pub fn take_session_stats(&self) -> SessionStats {

--- a/src/scripting/alternator/context.rs
+++ b/src/scripting/alternator/context.rs
@@ -17,6 +17,7 @@ pub struct Context {
     client: Option<Client>,
     page_size: u64,
     pub stats: Arc<TryLock<SessionStats>>,
+    pub report_metadata: Arc<TryLock<HashMap<String, String>>>,
     pub start_time: TryLock<Instant>,
     pub retry_number: u64,
     pub retry_interval: RetryInterval,
@@ -43,6 +44,7 @@ impl Context {
             client,
             page_size,
             stats: Arc::new(TryLock::new(SessionStats::new())),
+            report_metadata: Arc::new(TryLock::new(HashMap::new())),
             start_time: TryLock::new(Instant::now()),
             retry_number,
             retry_interval,
@@ -60,6 +62,9 @@ impl Context {
             client: self.client.clone(),
             page_size: self.page_size,
             stats: Arc::new(TryLock::new(SessionStats::default())),
+            report_metadata: Arc::new(TryLock::new(
+                self.report_metadata.try_lock().unwrap().clone(),
+            )),
             start_time: TryLock::new(*self.start_time.try_lock().unwrap()),
             retry_number: self.retry_number,
             retry_interval: self.retry_interval,
@@ -79,6 +84,7 @@ impl Context {
             client: self.client.clone(),
             page_size: self.page_size,
             stats: Arc::clone(&self.stats),
+            report_metadata: Arc::clone(&self.report_metadata),
             start_time: TryLock::new(*self.start_time.try_lock().unwrap()),
             retry_number: self.retry_number,
             retry_interval: self.retry_interval,
@@ -141,6 +147,17 @@ impl Context {
 
         // We couldn't determine the cluster info.
         Ok(None)
+    }
+
+    pub fn set_report_field(&self, key: &str, value: &str) {
+        self.report_metadata
+            .try_lock()
+            .unwrap()
+            .insert(key.to_string(), value.to_string());
+    }
+
+    pub fn report_metadata_snapshot(&self) -> HashMap<String, String> {
+        self.report_metadata.try_lock().unwrap().clone()
     }
 
     pub fn take_session_stats(&self) -> SessionStats {

--- a/src/scripting/cql/context.rs
+++ b/src/scripting/cql/context.rs
@@ -40,6 +40,7 @@ pub struct Context {
     statements: Arc<TryLock<HashMap<String, Arc<PreparedStatement>>>>,
     pub stats: Arc<TryLock<SessionStats>>,
     pub report_metadata: Arc<TryLock<HashMap<String, String>>>,
+    pub metric_orientations: Arc<TryLock<HashMap<String, i8>>>,
     pub retry_number: u64,
     pub retry_interval: RetryInterval,
     pub validation_strategy: ValidationStrategy,
@@ -81,6 +82,7 @@ impl Context {
             statements: Arc::new(TryLock::new(HashMap::new())),
             stats: Arc::new(TryLock::new(SessionStats::new())),
             report_metadata: Arc::new(TryLock::new(HashMap::new())),
+            metric_orientations: Arc::new(TryLock::new(HashMap::new())),
             retry_number,
             retry_interval,
             validation_strategy,
@@ -107,6 +109,9 @@ impl Context {
             report_metadata: Arc::new(TryLock::new(
                 self.report_metadata.try_lock().unwrap().clone(),
             )),
+            metric_orientations: Arc::new(TryLock::new(
+                self.metric_orientations.try_lock().unwrap().clone(),
+            )),
             retry_number: self.retry_number,
             retry_interval: self.retry_interval,
             validation_strategy: self.validation_strategy,
@@ -132,6 +137,7 @@ impl Context {
             statements: Arc::clone(&self.statements),
             stats: Arc::clone(&self.stats),
             report_metadata: Arc::clone(&self.report_metadata),
+            metric_orientations: Arc::clone(&self.metric_orientations),
             retry_number: self.retry_number,
             retry_interval: self.retry_interval,
             validation_strategy: self.validation_strategy,
@@ -584,6 +590,21 @@ impl Context {
 
     pub fn report_metadata_snapshot(&self) -> HashMap<String, String> {
         self.report_metadata.try_lock().unwrap().clone()
+    }
+
+    pub fn record_metric(&self, name: &str, value: f64) {
+        self.stats.try_lock().unwrap().record_metric(name, value);
+    }
+
+    pub fn declare_metric(&self, name: &str, orientation: i8) {
+        self.metric_orientations
+            .try_lock()
+            .unwrap()
+            .insert(name.to_string(), orientation);
+    }
+
+    pub fn metric_orientations_snapshot(&self) -> HashMap<String, i8> {
+        self.metric_orientations.try_lock().unwrap().clone()
     }
 
     /// Returns the current accumulated request stats snapshot and resets the stats.

--- a/src/scripting/cql/context.rs
+++ b/src/scripting/cql/context.rs
@@ -39,6 +39,7 @@ pub struct Context {
     page_size: u64,
     statements: Arc<TryLock<HashMap<String, Arc<PreparedStatement>>>>,
     pub stats: Arc<TryLock<SessionStats>>,
+    pub report_metadata: Arc<TryLock<HashMap<String, String>>>,
     pub retry_number: u64,
     pub retry_interval: RetryInterval,
     pub validation_strategy: ValidationStrategy,
@@ -79,6 +80,7 @@ impl Context {
             page_size,
             statements: Arc::new(TryLock::new(HashMap::new())),
             stats: Arc::new(TryLock::new(SessionStats::new())),
+            report_metadata: Arc::new(TryLock::new(HashMap::new())),
             retry_number,
             retry_interval,
             validation_strategy,
@@ -102,6 +104,9 @@ impl Context {
             page_size: self.page_size,
             statements: Arc::new(TryLock::new(self.statements.try_lock().unwrap().clone())),
             stats: Arc::new(TryLock::new(SessionStats::default())),
+            report_metadata: Arc::new(TryLock::new(
+                self.report_metadata.try_lock().unwrap().clone(),
+            )),
             retry_number: self.retry_number,
             retry_interval: self.retry_interval,
             validation_strategy: self.validation_strategy,
@@ -126,6 +131,7 @@ impl Context {
             page_size: self.page_size,
             statements: Arc::clone(&self.statements),
             stats: Arc::clone(&self.stats),
+            report_metadata: Arc::clone(&self.report_metadata),
             retry_number: self.retry_number,
             retry_interval: self.retry_interval,
             validation_strategy: self.validation_strategy,
@@ -567,6 +573,17 @@ impl Context {
                 "'session' is not defined".to_string(),
             ))),
         }
+    }
+
+    pub fn set_report_field(&self, key: &str, value: &str) {
+        self.report_metadata
+            .try_lock()
+            .unwrap()
+            .insert(key.to_string(), value.to_string());
+    }
+
+    pub fn report_metadata_snapshot(&self) -> HashMap<String, String> {
+        self.report_metadata.try_lock().unwrap().clone()
     }
 
     /// Returns the current accumulated request stats snapshot and resets the stats.

--- a/src/scripting/cql/context.rs
+++ b/src/scripting/cql/context.rs
@@ -51,6 +51,10 @@ pub struct Context {
     pub preferred_datacenter: String,
     #[rune(get)]
     pub preferred_rack: String,
+    /// True on per-worker deep copies made by [`Context::clone`].
+    /// Run-level state written through such a copy (report metadata, metric
+    /// orientations) is never merged back, so the scripting API rejects those calls.
+    pub is_worker_clone: bool,
     #[rune(get)]
     pub data: Value,
 }
@@ -90,6 +94,7 @@ impl Context {
             load_cycle_count: 0,
             preferred_datacenter,
             preferred_rack,
+            is_worker_clone: false,
             data,
         }
     }
@@ -121,6 +126,7 @@ impl Context {
             load_cycle_count: self.load_cycle_count,
             preferred_datacenter: self.preferred_datacenter.clone(),
             preferred_rack: self.preferred_rack.clone(),
+            is_worker_clone: true,
             data: deserialized,
             start_time: TryLock::new(*self.start_time.try_lock().unwrap()),
         })
@@ -145,6 +151,7 @@ impl Context {
             load_cycle_count: self.load_cycle_count,
             preferred_datacenter: self.preferred_datacenter.clone(),
             preferred_rack: self.preferred_rack.clone(),
+            is_worker_clone: self.is_worker_clone,
             data: self.data.clone(),
         }
     }

--- a/src/scripting/functions_common.rs
+++ b/src/scripting/functions_common.rs
@@ -330,3 +330,28 @@ pub fn elapsed_secs(ctx: &Context) -> f64 {
 pub fn set_report_field(ctx: &Context, key: Ref<str>, value: Ref<str>) {
     ctx.set_report_field(&key, &value);
 }
+
+#[rune::function(instance)]
+pub fn record_metric(ctx: &Context, name: Ref<str>, value: f64) -> VmResult<()> {
+    if !value.is_finite() {
+        return VmResult::panic(format!(
+            "record_metric: value for metric \"{}\" must be a finite number, got {value}",
+            &*name
+        ));
+    }
+    ctx.record_metric(&name, value);
+    VmResult::Ok(())
+}
+
+#[rune::function(instance)]
+pub fn declare_metric(ctx: &Context, name: Ref<str>, orientation: Ref<str>) -> VmResult<()> {
+    let orientation = vm_try!(match &*orientation {
+        "higher" => Ok(1),
+        "lower" => Ok(-1),
+        other => Err(VmError::panic(format!(
+            "declare_metric: orientation must be \"higher\" or \"lower\", got \"{other}\""
+        ))),
+    });
+    ctx.declare_metric(&name, orientation);
+    VmResult::Ok(())
+}

--- a/src/scripting/functions_common.rs
+++ b/src/scripting/functions_common.rs
@@ -326,13 +326,44 @@ pub fn elapsed_secs(ctx: &Context) -> f64 {
     ctx.start_time.try_lock().unwrap().elapsed().as_secs_f64()
 }
 
+/// Rejects calls that write run-level report state from a worker-cloned
+/// context: workers operate on per-thread copies that are never merged back,
+/// so such writes would be silently lost.
+fn reject_in_workload(ctx: &Context, function: &str) -> Result<(), VmError> {
+    if ctx.is_worker_clone {
+        return Err(VmError::panic(format!(
+            "{function} is only allowed in single-threaded setup functions \
+             such as prepare, schema or erase; called from a workload function \
+             it would have no effect. Use record_metric for per-cycle values."
+        )));
+    }
+    Ok(())
+}
+
+/// Rejects per-cycle calls from a setup function (prepare/schema/erase): those
+/// run on the original context whose stats are reset before the run, so the
+/// value would be silently dropped. The mirror of `reject_in_workload`.
+fn reject_in_setup(ctx: &Context, function: &str) -> Result<(), VmError> {
+    if !ctx.is_worker_clone {
+        return Err(VmError::panic(format!(
+            "{function} only takes effect inside workload functions; called from \
+             a setup function such as prepare, schema or erase its value would be \
+             discarded before the run."
+        )));
+    }
+    Ok(())
+}
+
 #[rune::function(instance)]
-pub fn set_report_field(ctx: &Context, key: Ref<str>, value: Ref<str>) {
+pub fn set_report_field(ctx: &Context, key: Ref<str>, value: Ref<str>) -> VmResult<()> {
+    vm_try!(reject_in_workload(ctx, "set_report_field"));
     ctx.set_report_field(&key, &value);
+    VmResult::Ok(())
 }
 
 #[rune::function(instance)]
 pub fn record_metric(ctx: &Context, name: Ref<str>, value: f64) -> VmResult<()> {
+    vm_try!(reject_in_setup(ctx, "record_metric"));
     if !value.is_finite() {
         return VmResult::panic(format!(
             "record_metric: value for metric \"{}\" must be a finite number, got {value}",
@@ -345,6 +376,7 @@ pub fn record_metric(ctx: &Context, name: Ref<str>, value: f64) -> VmResult<()> 
 
 #[rune::function(instance)]
 pub fn declare_metric(ctx: &Context, name: Ref<str>, orientation: Ref<str>) -> VmResult<()> {
+    vm_try!(reject_in_workload(ctx, "declare_metric"));
     let orientation = vm_try!(match &*orientation {
         "higher" => Ok(1),
         "lower" => Ok(-1),
@@ -354,4 +386,65 @@ pub fn declare_metric(ctx: &Context, name: Ref<str>, orientation: Ref<str>) -> V
     });
     ctx.declare_metric(&name, orientation);
     VmResult::Ok(())
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::config::{RetryInterval, ValidationStrategy};
+
+    #[cfg(feature = "cql")]
+    fn test_context() -> Context {
+        Context::new(
+            None,
+            501,
+            "dc".to_string(),
+            "rack".to_string(),
+            0,
+            RetryInterval::new("1,2").expect("failed to parse retry interval"),
+            ValidationStrategy::Ignore,
+        )
+    }
+
+    #[cfg(all(feature = "alternator", not(feature = "cql")))]
+    fn test_context() -> Context {
+        Context::new(
+            None,
+            0,
+            RetryInterval::new("1,2").expect("failed to parse retry interval"),
+            ValidationStrategy::Ignore,
+            0,
+        )
+    }
+
+    #[test]
+    fn worker_clone_flag_propagates() {
+        let original = test_context();
+        assert!(!original.is_worker_clone);
+        assert!(!original.shallow_clone().is_worker_clone);
+
+        let worker = original.clone().unwrap();
+        assert!(worker.is_worker_clone);
+        assert!(worker.shallow_clone().is_worker_clone);
+    }
+
+    #[test]
+    fn report_state_writes_rejected_in_worker_clone() {
+        let original = test_context();
+        assert!(reject_in_workload(&original, "set_report_field").is_ok());
+        assert!(reject_in_workload(&original, "declare_metric").is_ok());
+
+        let worker = original.clone().unwrap();
+        assert!(reject_in_workload(&worker, "set_report_field").is_err());
+        assert!(reject_in_workload(&worker, "declare_metric").is_err());
+    }
+
+    #[test]
+    fn record_metric_rejected_in_setup_context() {
+        let original = test_context();
+        assert!(reject_in_setup(&original, "record_metric").is_err());
+
+        let worker = original.clone().unwrap();
+        assert!(reject_in_setup(&worker, "record_metric").is_ok());
+    }
 }

--- a/src/scripting/functions_common.rs
+++ b/src/scripting/functions_common.rs
@@ -325,3 +325,8 @@ pub async fn signal_failure(_ctx: Ref<Context>, message: Ref<str>) -> Result<(),
 pub fn elapsed_secs(ctx: &Context) -> f64 {
     ctx.start_time.try_lock().unwrap().elapsed().as_secs_f64()
 }
+
+#[rune::function(instance)]
+pub fn set_report_field(ctx: &Context, key: Ref<str>, value: Ref<str>) {
+    ctx.set_report_field(&key, &value);
+}

--- a/src/scripting/mod.rs
+++ b/src/scripting/mod.rs
@@ -137,6 +137,8 @@ fn init_context_module() -> Result<Module, ContextError> {
     context_module.function_meta(functions_common::signal_failure)?;
     context_module.function_meta(functions_common::elapsed_secs)?;
     context_module.function_meta(functions_common::set_report_field)?;
+    context_module.function_meta(functions_common::record_metric)?;
+    context_module.function_meta(functions_common::declare_metric)?;
 
     context_module.function_meta(row_distribution::init_partition_row_distribution_preset)?;
     context_module.function_meta(row_distribution::get_partition_idx)?;

--- a/src/scripting/mod.rs
+++ b/src/scripting/mod.rs
@@ -136,6 +136,7 @@ fn init_context_module() -> Result<Module, ContextError> {
     context_module.ty::<context::Context>()?;
     context_module.function_meta(functions_common::signal_failure)?;
     context_module.function_meta(functions_common::elapsed_secs)?;
+    context_module.function_meta(functions_common::set_report_field)?;
 
     context_module.function_meta(row_distribution::init_partition_row_distribution_preset)?;
     context_module.function_meta(row_distribution::get_partition_idx)?;

--- a/src/stats/histogram.rs
+++ b/src/stats/histogram.rs
@@ -14,6 +14,18 @@ use serde::{Deserialize, Deserializer, Serialize};
 #[derive(Debug)]
 pub struct SerializableHistogram(pub Histogram<u64>);
 
+impl SerializableHistogram {
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+impl Default for SerializableHistogram {
+    fn default() -> Self {
+        SerializableHistogram(Histogram::new(3).unwrap())
+    }
+}
+
 impl Serialize for SerializableHistogram {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where

--- a/src/stats/mod.rs
+++ b/src/stats/mod.rs
@@ -6,6 +6,7 @@ use std::time::{Duration, Instant, SystemTime};
 
 use crate::exec::workload::WorkloadStats;
 use crate::stats::latency::{LatencyDistribution, LatencyDistributionRecorder};
+use crate::stats::value::{ValueDistribution, ValueDistributionRecorder};
 use cpu_time::ProcessTime;
 use hdrhistogram::serialization::interval_log;
 use percentiles::Percentile;
@@ -19,8 +20,10 @@ pub mod histogram;
 pub mod latency;
 pub mod percentiles;
 pub mod session;
+pub mod signed_histogram;
 pub mod throughput;
 pub mod timeseries;
+pub mod value;
 
 /// Computes the natural logarithm of the gamma function using the Lanczos approximation.
 /// See: https://en.wikipedia.org/wiki/Lanczos_approximation
@@ -233,6 +236,8 @@ pub struct Sample {
     pub cycle_latency: LatencyDistribution,
     pub cycle_latency_by_fn: HashMap<String, LatencyDistribution>,
     pub request_latency: LatencyDistribution,
+    #[serde(default)]
+    pub custom_metrics: HashMap<String, ValueDistribution>,
 }
 
 impl Sample {
@@ -253,11 +258,18 @@ impl Sample {
         let mut request_latency = LatencyDistributionRecorder::default();
         let mut cycle_latency = LatencyDistributionRecorder::default();
         let mut cycle_latency_per_fn = HashMap::<String, LatencyDistributionRecorder>::new();
+        let mut custom_metrics = HashMap::<String, ValueDistributionRecorder>::new();
 
         for s in stats {
             let ss = &s.session_stats;
             request_count += ss.req_count;
             row_count += ss.row_count;
+            for (name, recorder) in &ss.custom_metrics {
+                custom_metrics
+                    .entry(name.clone())
+                    .or_default()
+                    .add(recorder);
+            }
             if errors.len() < MAX_KEPT_ERRORS {
                 errors.extend(ss.req_errors.iter().cloned());
             }
@@ -303,6 +315,11 @@ impl Sample {
                 .collect(),
 
             request_latency: request_latency.distribution(),
+
+            custom_metrics: custom_metrics
+                .into_iter()
+                .map(|(k, v)| (k, v.distribution()))
+                .collect(),
         }
     }
 }
@@ -332,11 +349,23 @@ pub struct BenchmarkStats {
     pub cycle_latency: LatencyDistribution,
     pub cycle_latency_by_fn: HashMap<String, LatencyDistribution>,
     pub request_latency: Option<LatencyDistribution>,
+    #[serde(default)]
+    pub custom_metrics: HashMap<String, CustomMetric>,
     pub concurrency: Mean,
     pub concurrency_ratio: f64,
     #[serde(default)]
     pub run_metadata: HashMap<String, String>,
     pub log: Vec<Sample>,
+}
+
+/// A workload-defined metric: the distribution of its recorded values
+/// together with the orientation declared by the workload script
+/// (1 = higher is better, -1 = lower is better, 0 = undeclared).
+#[derive(Serialize, Deserialize, Debug)]
+pub struct CustomMetric {
+    pub distribution: ValueDistribution,
+    #[serde(default)]
+    pub orientation: i8,
 }
 
 /// Stores the statistics of one or two test runs.
@@ -419,6 +448,7 @@ pub struct Recorder<'a> {
     pub cycle_latency: LatencyDistributionRecorder,
     pub cycle_latency_by_fn: HashMap<String, LatencyDistributionRecorder>,
     pub request_latency: LatencyDistributionRecorder,
+    pub custom_metrics: HashMap<String, ValueDistributionRecorder>,
     pub concurrency_meter: TimeSeriesStats,
     log: Vec<Sample>,
     rate_limit: Option<f64>,
@@ -459,6 +489,7 @@ impl Recorder<'_> {
             cycle_latency: LatencyDistributionRecorder::default(),
             cycle_latency_by_fn: HashMap::new(),
             request_latency: LatencyDistributionRecorder::default(),
+            custom_metrics: HashMap::new(),
             throughput_meter: ThroughputMeter::default(),
             concurrency_meter: TimeSeriesStats::default(),
             keep_log,
@@ -479,6 +510,12 @@ impl Recorder<'_> {
         };
         for s in workload_stats.iter() {
             self.request_latency.add(&s.session_stats.resp_times_ns);
+            for (name, recorder) in &s.session_stats.custom_metrics {
+                self.custom_metrics
+                    .entry(name.clone())
+                    .or_default()
+                    .add(recorder);
+            }
             for fs in &s.function_stats {
                 self.cycle_latency.add(&fs.call_latency);
                 self.cycle_latency_by_fn
@@ -590,6 +627,17 @@ impl Recorder<'_> {
             } else {
                 None
             },
+            custom_metrics: self
+                .custom_metrics
+                .into_iter()
+                .map(|(k, v)| {
+                    let metric = CustomMetric {
+                        distribution: v.distribution_with_errors(),
+                        orientation: 0,
+                    };
+                    (k, metric)
+                })
+                .collect(),
             concurrency,
             concurrency_ratio,
             run_metadata,
@@ -632,6 +680,7 @@ mod test {
             cycle_latency: LatencyDistributionRecorder::default().distribution(),
             cycle_latency_by_fn: std::collections::HashMap::new(),
             request_latency: None,
+            custom_metrics: std::collections::HashMap::new(),
             concurrency: mean,
             concurrency_ratio: 100.0,
             run_metadata: std::collections::HashMap::new(),
@@ -655,13 +704,45 @@ mod test {
     }
 
     #[test]
-    fn benchmark_stats_without_run_metadata_still_loads() {
-        // Reports generated before the run_metadata field existed must keep loading.
+    fn benchmark_stats_from_older_latte_versions_still_loads() {
+        // Reports generated before the run_metadata and custom_metrics fields
+        // existed must keep loading.
         let json = serde_json::to_string(&sample_benchmark_stats()).unwrap();
         let mut value: serde_json::Value = serde_json::from_str(&json).unwrap();
         value.as_object_mut().unwrap().remove("run_metadata");
+        value.as_object_mut().unwrap().remove("custom_metrics");
         let parsed: super::BenchmarkStats = serde_json::from_value(value).unwrap();
         assert!(parsed.run_metadata.is_empty());
+        assert!(parsed.custom_metrics.is_empty());
+    }
+
+    #[test]
+    fn benchmark_stats_custom_metrics_roundtrip_through_json() {
+        let mut stats = sample_benchmark_stats();
+        let mut recorder = crate::stats::value::ValueDistributionRecorder::default();
+        recorder.record(crate::stats::value::MetricValue(0.9933));
+        stats.custom_metrics.insert(
+            "recall".to_string(),
+            super::CustomMetric {
+                distribution: recorder.distribution(),
+                orientation: 1,
+            },
+        );
+
+        let json = serde_json::to_string(&stats).unwrap();
+        let parsed: super::BenchmarkStats = serde_json::from_str(&json).unwrap();
+        let recall = parsed.custom_metrics.get("recall").unwrap();
+        assert!((recall.distribution.mean.value - 0.9933).abs() < 0.001);
+        assert_eq!(recall.orientation, 1);
+
+        // Entries without an orientation (older reports) must default to neutral.
+        let mut value: serde_json::Value = serde_json::from_str(&json).unwrap();
+        value["custom_metrics"]["recall"]
+            .as_object_mut()
+            .unwrap()
+            .remove("orientation");
+        let parsed: super::BenchmarkStats = serde_json::from_value(value).unwrap();
+        assert_eq!(parsed.custom_metrics.get("recall").unwrap().orientation, 0);
     }
 
     #[test]

--- a/src/stats/mod.rs
+++ b/src/stats/mod.rs
@@ -424,6 +424,23 @@ impl BenchmarkCmp<'_> {
     pub fn cmp_resp_time_percentile(&self, p: Percentile) -> Option<Significance> {
         self.cmp(|s| s.request_latency.as_ref().map(|r| r.percentiles.get(p)))
     }
+
+    /// Checks if the mean of a workload-defined metric of two benchmark runs
+    /// is significantly different. Returns None if the second benchmark is unset.
+    pub fn cmp_mean_custom_metric(&self, name: &str) -> Option<Significance> {
+        self.cmp(|s| s.custom_metrics.get(name).map(|m| m.distribution.mean))
+    }
+
+    /// Checks if corresponding percentiles of a workload-defined metric of two
+    /// benchmark runs are significantly different.
+    /// Returns None if the second benchmark is unset.
+    pub fn cmp_custom_metric_percentile(&self, name: &str, p: Percentile) -> Option<Significance> {
+        self.cmp(|s| {
+            s.custom_metrics
+                .get(name)
+                .map(|m| m.distribution.percentiles.get(p))
+        })
+    }
 }
 
 /// Observes requests and computes their statistics such as mean throughput, mean response time,
@@ -748,6 +765,38 @@ mod test {
             .remove("orientation");
         let parsed: super::BenchmarkStats = serde_json::from_value(value).unwrap();
         assert_eq!(parsed.custom_metrics.get("recall").unwrap().orientation, 0);
+    }
+
+    #[test]
+    fn cmp_custom_metric_computes_significance() {
+        let recall_metric = |values: &[f64]| {
+            let mut recorder = crate::stats::value::ValueDistributionRecorder::default();
+            for v in values {
+                recorder.record(crate::stats::value::MetricValue(*v));
+            }
+            super::CustomMetric {
+                distribution: recorder.distribution_with_errors(),
+                orientation: 1,
+            }
+        };
+        let mut v1 = sample_benchmark_stats();
+        let mut v2 = sample_benchmark_stats();
+        v1.custom_metrics
+            .insert("recall".to_string(), recall_metric(&[0.97, 0.98, 0.99]));
+        v2.custom_metrics
+            .insert("recall".to_string(), recall_metric(&[0.97, 0.98, 0.99]));
+
+        let cmp = super::BenchmarkCmp {
+            v1: &v1,
+            v2: Some(&v2),
+        };
+        // Identical distributions must not be reported as significantly different.
+        let significance = cmp.cmp_mean_custom_metric("recall").unwrap();
+        assert!(significance.0 > 0.05);
+        assert!(cmp.cmp_mean_custom_metric("no_such_metric").is_none());
+
+        let single = super::BenchmarkCmp { v1: &v1, v2: None };
+        assert!(single.cmp_mean_custom_metric("recall").is_none());
     }
 
     #[test]

--- a/src/stats/mod.rs
+++ b/src/stats/mod.rs
@@ -334,6 +334,8 @@ pub struct BenchmarkStats {
     pub request_latency: Option<LatencyDistribution>,
     pub concurrency: Mean,
     pub concurrency_ratio: f64,
+    #[serde(default)]
+    pub run_metadata: HashMap<String, String>,
     pub log: Vec<Sample>,
 }
 
@@ -531,7 +533,7 @@ impl Recorder<'_> {
     }
 
     /// Stops the recording, computes the statistics and returns them as the new object.
-    pub fn finish(mut self) -> BenchmarkStats {
+    pub fn finish(mut self, run_metadata: HashMap<String, String>) -> BenchmarkStats {
         self.end_time = SystemTime::now();
         self.end_instant = Instant::now();
         self.end_cpu_time = ProcessTime::now();
@@ -590,6 +592,7 @@ impl Recorder<'_> {
             },
             concurrency,
             concurrency_ratio,
+            run_metadata,
             log: self.log,
         }
     }
@@ -598,6 +601,68 @@ impl Recorder<'_> {
 #[cfg(test)]
 mod test {
     use crate::stats::{ln_gamma, regularized_incomplete_beta, students_t_cdf, t_test, Mean};
+
+    fn sample_benchmark_stats() -> super::BenchmarkStats {
+        use super::latency::LatencyDistributionRecorder;
+        let mean = Mean {
+            n: 1,
+            value: 1.0,
+            std_err: None,
+        };
+        super::BenchmarkStats {
+            start_time: chrono::Local::now(),
+            end_time: chrono::Local::now(),
+            elapsed_time_s: 1.0,
+            cpu_time_s: 0.5,
+            cpu_util: 50.0,
+            cycle_count: 10,
+            request_count: 10,
+            requests_per_cycle: 1.0,
+            request_retry_count: 0,
+            request_retry_per_request: Some(0.0),
+            errors: Vec::new(),
+            error_count: 0,
+            errors_ratio: Some(0.0),
+            row_count: 0,
+            row_count_per_req: Some(0.0),
+            cycle_throughput: mean,
+            cycle_throughput_ratio: None,
+            req_throughput: mean,
+            row_throughput: mean,
+            cycle_latency: LatencyDistributionRecorder::default().distribution(),
+            cycle_latency_by_fn: std::collections::HashMap::new(),
+            request_latency: None,
+            concurrency: mean,
+            concurrency_ratio: 100.0,
+            run_metadata: std::collections::HashMap::new(),
+            log: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn benchmark_stats_run_metadata_roundtrips_through_json() {
+        let mut stats = sample_benchmark_stats();
+        stats
+            .run_metadata
+            .insert("dataset".to_string(), "test_dataset".to_string());
+
+        let json = serde_json::to_string(&stats).unwrap();
+        let parsed: super::BenchmarkStats = serde_json::from_str(&json).unwrap();
+        assert_eq!(
+            parsed.run_metadata.get("dataset"),
+            Some(&"test_dataset".to_string())
+        );
+    }
+
+    #[test]
+    fn benchmark_stats_without_run_metadata_still_loads() {
+        // Reports generated before the run_metadata field existed must keep loading.
+        let json = serde_json::to_string(&sample_benchmark_stats()).unwrap();
+        let mut value: serde_json::Value = serde_json::from_str(&json).unwrap();
+        value.as_object_mut().unwrap().remove("run_metadata");
+        let parsed: super::BenchmarkStats = serde_json::from_value(value).unwrap();
+        assert!(parsed.run_metadata.is_empty());
+    }
 
     #[test]
     fn ln_gamma_known_values() {

--- a/src/stats/mod.rs
+++ b/src/stats/mod.rs
@@ -570,7 +570,11 @@ impl Recorder<'_> {
     }
 
     /// Stops the recording, computes the statistics and returns them as the new object.
-    pub fn finish(mut self, run_metadata: HashMap<String, String>) -> BenchmarkStats {
+    pub fn finish(
+        mut self,
+        run_metadata: HashMap<String, String>,
+        metric_orientations: HashMap<String, i8>,
+    ) -> BenchmarkStats {
         self.end_time = SystemTime::now();
         self.end_instant = Instant::now();
         self.end_cpu_time = ProcessTime::now();
@@ -631,9 +635,10 @@ impl Recorder<'_> {
                 .custom_metrics
                 .into_iter()
                 .map(|(k, v)| {
+                    let orientation = metric_orientations.get(&k).copied().unwrap_or(0);
                     let metric = CustomMetric {
                         distribution: v.distribution_with_errors(),
-                        orientation: 0,
+                        orientation,
                     };
                     (k, metric)
                 })

--- a/src/stats/percentiles.rs
+++ b/src/stats/percentiles.rs
@@ -75,12 +75,12 @@ impl Percentiles {
 
     /// Computes distribution percentiles without errors.
     /// Fast.
-    pub fn compute(histogram: &Histogram<u64>, scale: f64) -> Percentiles {
+    pub fn compute<S: PercentileSource>(source: &S, scale: f64) -> Percentiles {
         let mut result = Vec::with_capacity(Percentile::COUNT);
         for p in Percentile::iter() {
             result.push(Mean {
                 n: Self::POPULATION_SIZE as u64,
-                value: histogram.value_at_percentile(p.value()) as f64 * scale,
+                value: source.value_at_percentile(p.value()) * scale,
                 std_err: None,
             });
         }
@@ -88,12 +88,12 @@ impl Percentiles {
         Percentiles(result.try_into().unwrap())
     }
 
-    /// Computes distribution percentiles with errors based on a HDR histogram.
+    /// Computes distribution percentiles with errors based on the distribution.
     /// Caution: this is slow. Don't use it when benchmark is running!
-    /// Errors are estimated by bootstrapping a larger population of histograms from the
-    /// distribution determined by the original histogram and computing the standard error.
-    pub fn compute_with_errors(
-        histogram: &Histogram<u64>,
+    /// Errors are estimated by bootstrapping a larger population from the
+    /// distribution and computing the standard error.
+    pub fn compute_with_errors<S: PercentileSource>(
+        source: &S,
         scale: f64,
         effective_sample_size: u64,
     ) -> Percentiles {
@@ -102,7 +102,7 @@ impl Percentiles {
         let mut samples: Vec<[f64; Percentile::COUNT]> = Vec::with_capacity(Self::POPULATION_SIZE);
         for _ in 0..Self::POPULATION_SIZE {
             samples.push(percentiles(
-                &bootstrap(&mut rng, histogram, effective_sample_size),
+                &source.bootstrap(&mut rng, effective_sample_size),
                 scale,
             ))
         }
@@ -116,7 +116,7 @@ impl Percentiles {
             let std_err = variance.sqrt();
             result.push(Mean {
                 n: Self::POPULATION_SIZE as u64,
-                value: histogram.value_at_percentile(p.value()) as f64 * scale,
+                value: source.value_at_percentile(p.value()) * scale,
                 std_err: Some(std_err),
             });
         }
@@ -130,6 +130,35 @@ impl Percentiles {
     }
 }
 
+/// A distribution that percentile statistics can be computed from.
+/// Implemented for a plain HDR histogram and for the signed two-store
+/// histogram, so one percentile engine serves both.
+pub trait PercentileSource: Sized {
+    /// Value at the given percentile, in histogram units (may be negative).
+    fn value_at_percentile(&self, percentile: f64) -> f64;
+
+    /// Resamples the distribution for bootstrap error estimation.
+    fn bootstrap(&self, rng: &mut SmallRng, effective_n: u64) -> Self;
+}
+
+impl PercentileSource for Histogram<u64> {
+    fn value_at_percentile(&self, percentile: f64) -> f64 {
+        Histogram::value_at_percentile(self, percentile) as f64
+    }
+
+    fn bootstrap(&self, rng: &mut SmallRng, effective_n: u64) -> Self {
+        bootstrap(rng, self, effective_n)
+    }
+}
+
+fn percentiles<S: PercentileSource>(source: &S, scale: f64) -> [f64; Percentile::COUNT] {
+    let mut percentiles = [0.0; Percentile::COUNT];
+    for (i, p) in Percentile::iter().enumerate() {
+        percentiles[i] = source.value_at_percentile(p.value()) * scale;
+    }
+    percentiles
+}
+
 /// Maximum chunk size used when bootstrapping histograms.
 ///
 /// The `rand` crate internally uses `i32` for some operations and will panic if asked
@@ -140,15 +169,27 @@ const MAX_BOOTSTRAP_CHUNK_SIZE: u64 = 2_000_000_000;
 
 /// Creates a new random histogram using another histogram as the distribution.
 fn bootstrap(rng: &mut impl Rng, histogram: &Histogram<u64>, effective_n: u64) -> Histogram<u64> {
-    let n = histogram.len();
-    if n <= 1 {
+    bootstrap_from_total(rng, histogram, histogram.len(), effective_n)
+}
+
+/// Creates a new random histogram using `histogram` as one part of a larger
+/// distribution holding `total_n` values overall. Bucket probabilities are
+/// computed against `total_n`, so the two stores of a signed distribution
+/// can be resampled consistently with each other.
+pub(crate) fn bootstrap_from_total(
+    rng: &mut impl Rng,
+    histogram: &Histogram<u64>,
+    total_n: u64,
+    effective_n: u64,
+) -> Histogram<u64> {
+    if total_n <= 1 {
         return histogram.clone();
     }
     let mut result =
         Histogram::new_with_bounds(histogram.low(), histogram.high(), histogram.sigfig()).unwrap();
 
     for bucket in histogram.iter_recorded() {
-        let p = bucket.count_at_value() as f64 / n as f64;
+        let p = bucket.count_at_value() as f64 / total_n as f64;
         assert!(p > 0.0, "Probability must be greater than 0.0");
         // NOTE: 'rand' lib panics if n > i32::MAX, so, use chunks smaller than that value
         //       see https://github.com/scylladb/latte/issues/115
@@ -169,14 +210,6 @@ fn bootstrap(rng: &mut impl Rng, histogram: &Histogram<u64>, effective_n: u64) -
             .unwrap()
     }
     result
-}
-
-fn percentiles(hist: &Histogram<u64>, scale: f64) -> [f64; Percentile::COUNT] {
-    let mut percentiles = [0.0; Percentile::COUNT];
-    for (i, p) in Percentile::iter().enumerate() {
-        percentiles[i] = hist.value_at_percentile(p.value()) as f64 * scale;
-    }
-    percentiles
 }
 
 #[cfg(test)]

--- a/src/stats/session.rs
+++ b/src/stats/session.rs
@@ -1,5 +1,6 @@
 use crate::config::PRINT_RETRY_ERROR_LIMIT;
 use crate::stats::latency::LatencyDistributionRecorder;
+use crate::stats::value::MetricValue;
 use crate::stats::value::ValueDistributionRecorder;
 use std::collections::{HashMap, HashSet};
 use std::time::Duration;
@@ -38,6 +39,19 @@ impl SessionStats {
         self.resp_times_ns.record(duration);
         self.req_count += 1;
         self.row_count += row_count;
+    }
+
+    pub fn record_metric(&mut self, name: &str, value: f64) {
+        // Called every cycle: avoid allocating the key on the hot path when the
+        // metric already exists.
+        if let Some(recorder) = self.custom_metrics.get_mut(name) {
+            recorder.record(MetricValue(value));
+        } else {
+            self.custom_metrics
+                .entry(name.to_string())
+                .or_default()
+                .record(MetricValue(value));
+        }
     }
 
     pub fn store_retry_error(&mut self, error_str: String) {

--- a/src/stats/session.rs
+++ b/src/stats/session.rs
@@ -1,6 +1,7 @@
 use crate::config::PRINT_RETRY_ERROR_LIMIT;
 use crate::stats::latency::LatencyDistributionRecorder;
-use std::collections::HashSet;
+use crate::stats::value::ValueDistributionRecorder;
+use std::collections::{HashMap, HashSet};
 use std::time::Duration;
 use tokio::time::Instant;
 
@@ -15,6 +16,7 @@ pub struct SessionStats {
     pub queue_length: u64,
     pub mean_queue_length: f32,
     pub resp_times_ns: LatencyDistributionRecorder,
+    pub custom_metrics: HashMap<String, ValueDistributionRecorder>,
 }
 
 impl SessionStats {
@@ -55,6 +57,7 @@ impl SessionStats {
         self.req_errors.clear();
         self.req_retry_errors.clear();
         self.resp_times_ns.clear();
+        self.custom_metrics.clear();
 
         // note that current queue_length is *not* reset to zero because there
         // might be pending requests and if we set it to zero, that would underflow
@@ -73,6 +76,7 @@ impl Default for SessionStats {
             queue_length: 0,
             mean_queue_length: 0.0,
             resp_times_ns: LatencyDistributionRecorder::default(),
+            custom_metrics: HashMap::new(),
         }
     }
 }

--- a/src/stats/signed_histogram.rs
+++ b/src/stats/signed_histogram.rs
@@ -1,0 +1,477 @@
+use crate::stats::percentiles::{bootstrap_from_total, PercentileSource};
+use hdrhistogram::{AdditionError, CreationError, Histogram, RecordError};
+use rand::rngs::SmallRng;
+
+/// A histogram over signed values built from two HDR histograms.
+///
+/// HDR stores only non-negative integers, so non-negative values (zero
+/// included) go to `positive` and magnitudes of negative values to `negative`
+/// — a DDSketch-style sign split that keeps HDR's relative precision symmetric
+/// around zero. It mirrors the `Histogram` interface the stats code uses, so a
+/// recorder can hold it wherever it would hold a plain histogram.
+#[derive(Clone, Debug)]
+pub struct SignedHistogram {
+    positive: Histogram<u64>,
+    negative: Histogram<u64>,
+}
+
+impl SignedHistogram {
+    /// Builds a SignedHistogram whose two stores both use `sigfig` significant
+    /// figures of precision, like `Histogram::new`. Both stores share the
+    /// precision so resolution stays symmetric around zero.
+    pub fn new(sigfig: u8) -> Result<Self, CreationError> {
+        Ok(Self {
+            positive: Histogram::new(sigfig)?,
+            negative: Histogram::new(sigfig)?,
+        })
+    }
+
+    /// Records a value given as a magnitude and a sign. Returns hdr's `Result`
+    /// like `Histogram::record`, leaving the propagate-or-unwrap choice to the
+    /// owning recorder.
+    pub fn record(&mut self, magnitude: u64, negative: bool) -> Result<(), RecordError> {
+        if negative {
+            self.negative.record(magnitude)
+        } else {
+            self.positive.record(magnitude)
+        }
+    }
+
+    pub fn add(&mut self, other: &SignedHistogram) -> Result<(), AdditionError> {
+        self.positive.add(&other.positive)?;
+        self.negative.add(&other.negative)
+    }
+
+    pub fn clear(&mut self) {
+        self.positive.clear();
+        self.negative.clear();
+    }
+
+    /// Total number of recorded values.
+    pub fn len(&self) -> u64 {
+        self.positive.len() + self.negative.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Non-negative recorded values, zero included.
+    pub fn positive(&self) -> &Histogram<u64> {
+        &self.positive
+    }
+
+    /// Magnitudes of negative recorded values.
+    pub fn negative(&self) -> &Histogram<u64> {
+        &self.negative
+    }
+
+    /// Mean of all recorded values, combining both stores. With no negatives it
+    /// reduces to the plain histogram's mean, up to floating-point rounding.
+    pub fn mean(&self) -> f64 {
+        if self.is_empty() {
+            return 0.0;
+        }
+        let positive_n = self.positive.len() as f64;
+        let negative_n = self.negative.len() as f64;
+        (self.positive.mean() * positive_n - self.negative.mean() * negative_n)
+            / (positive_n + negative_n)
+    }
+
+    /// Standard deviation of all recorded values, combining both stores.
+    pub fn stdev(&self) -> f64 {
+        if self.is_empty() {
+            return 0.0;
+        }
+        let positive_n = self.positive.len() as f64;
+        let negative_n = self.negative.len() as f64;
+        let n = positive_n + negative_n;
+        // Parallel-variance combine of the two groups (signed means +positive,
+        // -negative). Stays stable instead of cancelling E[X^2] against E[X]^2,
+        // which would understate or zero the variance for a large mean.
+        let m2_positive = self.positive.stdev().powi(2) * positive_n;
+        let m2_negative = self.negative.stdev().powi(2) * negative_n;
+        let mean_gap = self.positive.mean() + self.negative.mean();
+        let m2 = m2_positive + m2_negative + mean_gap * mean_gap * positive_n * negative_n / n;
+        (m2 / n).sqrt()
+    }
+
+    /// Value at the given percentile, negative for values from the `negative`
+    /// store. Follows the rank convention of `Histogram::value_at_percentile`
+    /// (target rank `max(1, ceil(percentile/100 * total))`, low edge at the
+    /// minimum and high edge elsewhere); with no negatives it reduces to exactly
+    /// `Histogram::value_at_percentile`, which the tests pin across every
+    /// percentile.
+    pub fn value_at_percentile(&self, percentile: f64) -> f64 {
+        let total = self.len();
+        if total == 0 {
+            return 0.0;
+        }
+        let quantile = (percentile / 100.0).min(1.0);
+        let target = ((quantile * total as f64).ceil() as u64).clamp(1, total);
+
+        let negative_count = self.negative.len();
+        if target <= negative_count {
+            // Negative values run opposite to magnitude order, so the target-th
+            // smallest value is the (negative_count - target + 1)-th smallest
+            // magnitude, found by walking magnitudes ascending.
+            let magnitude_rank = negative_count - target + 1;
+            let mut cumulative = 0;
+            for v in self.negative.iter_recorded() {
+                cumulative += v.count_since_last_iteration();
+                if cumulative >= magnitude_rank {
+                    let value = v.value_iterated_to();
+                    return if quantile == 0.0 {
+                        -(self.negative.highest_equivalent(value) as f64)
+                    } else {
+                        -(self.negative.lowest_equivalent(value) as f64)
+                    };
+                }
+            }
+            unreachable!("ranks up to negative.len() are covered by the negative store");
+        }
+        let mut cumulative = 0;
+        for v in self.positive.iter_recorded() {
+            cumulative += v.count_since_last_iteration();
+            if cumulative >= target - negative_count {
+                let value = v.value_iterated_to();
+                return if quantile == 0.0 {
+                    self.positive.lowest_equivalent(value) as f64
+                } else {
+                    self.positive.highest_equivalent(value) as f64
+                };
+            }
+        }
+        unreachable!("ranks above negative.len() are covered by the positive store");
+    }
+}
+
+impl Default for SignedHistogram {
+    fn default() -> Self {
+        Self::new(3).unwrap()
+    }
+}
+
+impl PercentileSource for SignedHistogram {
+    fn value_at_percentile(&self, percentile: f64) -> f64 {
+        SignedHistogram::value_at_percentile(self, percentile)
+    }
+
+    /// Resamples both stores against the combined value count, so the pair
+    /// stays consistent with the original sign split.
+    fn bootstrap(&self, rng: &mut SmallRng, effective_n: u64) -> Self {
+        let total = self.len();
+        SignedHistogram {
+            negative: bootstrap_from_total(rng, &self.negative, total, effective_n),
+            positive: bootstrap_from_total(rng, &self.positive, total, effective_n),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::stats::percentiles::{Percentile, Percentiles};
+    use assert_approx_eq::assert_approx_eq;
+    use rand::{Rng, SeedableRng};
+    use strum::IntoEnumIterator;
+
+    /// Records a signed integer magnitude into the two-store histogram.
+    fn record(hist: &mut SignedHistogram, v: i64) {
+        hist.record(v.unsigned_abs(), v < 0).unwrap();
+    }
+
+    /// True when two values agree up to floating-point rounding (relative).
+    fn approx_eq(a: f64, b: f64) -> bool {
+        (a - b).abs() <= 1e-9 * a.abs().max(b.abs()).max(1.0)
+    }
+
+    /// value_at_percentile must pick the right rank, store, and bucket edge.
+    /// The oracle independently sorts the raw values and applies the matching
+    /// store's edge function, so a wrong store or edge is caught exactly rather
+    /// than hidden by a tolerance. `n` spans integer ranks (100, 1000) and not.
+    #[test]
+    fn value_at_percentile_matches_per_store_oracle() {
+        let mut rng = SmallRng::seed_from_u64(7);
+        for &n in &[1usize, 2, 3, 10, 100, 1000, 1003] {
+            let mut hist = SignedHistogram::default();
+            let mut values: Vec<i64> = Vec::new();
+            for _ in 0..n {
+                let v: i64 = rng.random_range(-2_000_000..2_000_000);
+                values.push(v);
+                record(&mut hist, v);
+            }
+            values.sort();
+            for p in Percentile::iter() {
+                let quantile = (p.value() / 100.0).min(1.0);
+                let target = ((quantile * n as f64).ceil() as usize).clamp(1, n);
+                let v_t = values[target - 1];
+                let expected = if v_t < 0 {
+                    let mag = v_t.unsigned_abs();
+                    if quantile == 0.0 {
+                        -(hist.negative().highest_equivalent(mag) as f64)
+                    } else {
+                        -(hist.negative().lowest_equivalent(mag) as f64)
+                    }
+                } else if quantile == 0.0 {
+                    hist.positive().lowest_equivalent(v_t as u64) as f64
+                } else {
+                    hist.positive().highest_equivalent(v_t as u64) as f64
+                };
+                assert_eq!(
+                    hist.value_at_percentile(p.value()),
+                    expected,
+                    "n={n} percentile={}",
+                    p.value(),
+                );
+            }
+        }
+    }
+
+    /// At exact-integer ranks (quantile*total whole) the ceil convention makes
+    /// p and 100-p select adjacent magnitudes, not mirror images — e.g. p10 is
+    /// rank 1 (-500) but p90 is rank 9 (+400), not rank 10 (+500). This is the
+    /// one-rank gap `symmetric_distribution_is_antisymmetric` avoids with a
+    /// non-integer total. Unit-resolution magnitudes make the values exact.
+    #[test]
+    fn value_at_percentile_at_integer_ranks() {
+        let mut hist = SignedHistogram::default();
+        for m in [100u64, 200, 300, 400, 500] {
+            hist.record(m, false).unwrap();
+            hist.record(m, true).unwrap();
+        }
+        // sorted: [-500, -400, -300, -200, -100, 100, 200, 300, 400, 500], total 10
+        assert_eq!(hist.value_at_percentile(0.0), -500.0); // rank 1
+        assert_eq!(hist.value_at_percentile(10.0), -500.0); // rank ceil(1.0) = 1
+        assert_eq!(hist.value_at_percentile(50.0), -100.0); // rank ceil(5.0) = 5
+        assert_eq!(hist.value_at_percentile(90.0), 400.0); // rank ceil(9.0) = 9
+        assert_eq!(hist.value_at_percentile(100.0), 500.0); // rank 10
+    }
+
+    /// With no negatives, mean/stdev/every percentile must match a plain
+    /// histogram of the same precision — exercising the real combine (there is
+    /// no empty-negative fast path). Percentiles are exact; mean/stdev match up
+    /// to rounding. The high range puts the minimum in a wide bucket, where the
+    /// Min edge convention matters.
+    #[test]
+    fn nonneg_matches_plain_histogram() {
+        let mut rng = SmallRng::seed_from_u64(11);
+        let datasets: Vec<Vec<u64>> = vec![
+            vec![],                                                  // empty
+            vec![0],                                                 // single zero
+            vec![42],                                                // single value
+            vec![7; 1000],                                           // many identical
+            vec![0, 0, 0, 1, 1, 2],                                  // small, repeats, zeros
+            (0..2000).map(|_| rng.random_range(0..10u64)).collect(), // small range, many
+            (0..5000)
+                .map(|_| rng.random_range(0..2_000_000u64))
+                .collect(), // wide range
+            (0..3000)
+                .map(|_| rng.random_range(1_000_000..2_000_000u64))
+                .collect(), // high range, min in a wide bucket
+        ];
+        for data in datasets {
+            let mut signed = SignedHistogram::new(3).unwrap();
+            let mut plain = Histogram::<u64>::new(3).unwrap();
+            for &v in &data {
+                signed.record(v, false).unwrap();
+                plain.record(v).unwrap();
+            }
+            assert!(
+                approx_eq(signed.mean(), plain.mean()),
+                "mean, len {}: {} vs {}",
+                data.len(),
+                signed.mean(),
+                plain.mean(),
+            );
+            assert!(
+                approx_eq(signed.stdev(), plain.stdev()),
+                "stdev, len {}: {} vs {}",
+                data.len(),
+                signed.stdev(),
+                plain.stdev(),
+            );
+            for p in Percentile::iter() {
+                assert_eq!(
+                    signed.value_at_percentile(p.value()),
+                    plain.value_at_percentile(p.value()) as f64,
+                    "p{} on dataset of len {}",
+                    p.value(),
+                    data.len(),
+                );
+            }
+        }
+    }
+
+    /// A symmetric set (each magnitude as +m and -m) has mean exactly zero, and
+    /// percentiles antisymmetric up to one bucket width: for a magnitude m the
+    /// positive side reports +highest_equivalent(m) and the negative side
+    /// -lowest_equivalent(m), so p and 100-p sum to that bucket's width
+    /// (highest - lowest) rather than zero.
+    #[test]
+    fn symmetric_distribution_is_antisymmetric() {
+        let mut rng = SmallRng::seed_from_u64(13);
+        let mut hist = SignedHistogram::default();
+        // 2999 pairs keeps quantile*total non-integer for the tested
+        // percentiles, isolating the bucket-edge residual from the integer-rank
+        // gap (see value_at_percentile_at_integer_ranks).
+        for _ in 0..2999 {
+            let m = rng.random_range(1..2_000_000u64);
+            hist.record(m, false).unwrap();
+            hist.record(m, true).unwrap();
+        }
+
+        assert_eq!(hist.mean(), 0.0);
+
+        for (lo, hi) in [
+            (Percentile::P1, Percentile::P99),
+            (Percentile::P5, Percentile::P95),
+            (Percentile::P10, Percentile::P90),
+            (Percentile::P25, Percentile::P75),
+        ] {
+            let low = hist.value_at_percentile(lo.value());
+            let high = hist.value_at_percentile(hi.value());
+            assert!(
+                low < 0.0 && high > 0.0,
+                "p{}={low} p{}={high}",
+                lo.value(),
+                hi.value()
+            );
+            // Read -low back from the negative store to confirm it used the
+            // negative bucket; the residual is that bucket's edge gap.
+            let bucket = high as u64;
+            let bucket_width = high - hist.negative().lowest_equivalent(bucket) as f64;
+            assert!(
+                (low + high).abs() <= bucket_width + 1.0,
+                "p{}/p{}: low={low} high={high} sum={} bucket_width={bucket_width}",
+                lo.value(),
+                hi.value(),
+                low + high,
+            );
+        }
+    }
+
+    #[test]
+    fn compute_with_errors_on_degenerate_negative_distribution() {
+        let mut hist = SignedHistogram::default();
+        for _ in 0..100000 {
+            record(&mut hist, -1000);
+        }
+
+        let percentiles = Percentiles::compute_with_errors(&hist, 1e-6, 100000);
+        let median = percentiles.get(Percentile::P50);
+        assert_approx_eq!(median.value, -0.001, 0.00001);
+        assert_approx_eq!(median.std_err.unwrap(), 0.000, 1e-15);
+    }
+
+    /// `add` must merge both stores; percentiles after a merge must equal those
+    /// of a histogram built from all values directly (so merge is correct and
+    /// order-independent), not just the means checked in value.rs.
+    #[test]
+    fn add_merges_both_stores() {
+        let mut a = SignedHistogram::default();
+        for v in [100i64, 200, -300] {
+            record(&mut a, v);
+        }
+        let mut b = SignedHistogram::default();
+        for v in [50i64, -150, -250] {
+            record(&mut b, v);
+        }
+        a.add(&b).unwrap();
+        assert_eq!(a.positive().len(), 3); // 100, 200, 50
+        assert_eq!(a.negative().len(), 3); // 300, 150, 250
+        assert_eq!(a.len(), 6);
+
+        let mut direct = SignedHistogram::default();
+        for v in [100i64, 200, -300, 50, -150, -250] {
+            record(&mut direct, v);
+        }
+        for p in Percentile::iter() {
+            assert_eq!(
+                a.value_at_percentile(p.value()),
+                direct.value_at_percentile(p.value()),
+                "p{}",
+                p.value(),
+            );
+        }
+    }
+
+    /// `clear` must empty both stores and leave a reusable, fresh histogram.
+    #[test]
+    fn clear_empties_both_stores() {
+        let mut h = SignedHistogram::default();
+        for v in [5i64, -5, 0, 7] {
+            record(&mut h, v);
+        }
+        h.clear();
+        assert!(h.is_empty());
+        assert_eq!(h.len(), 0);
+        assert_eq!(h.positive().len(), 0);
+        assert_eq!(h.negative().len(), 0);
+        assert_eq!(h.mean(), 0.0);
+        assert_eq!(h.stdev(), 0.0);
+        assert_eq!(h.value_at_percentile(50.0), 0.0);
+        // No residual state: behaves like a fresh histogram.
+        record(&mut h, 42);
+        assert_eq!(h.len(), 1);
+        assert_eq!(h.value_at_percentile(50.0), 42.0);
+    }
+
+    /// An empty histogram reports zero for every summary, directly (the
+    /// `total == 0` / `is_empty` guards), not only via the plain-histogram
+    /// comparison.
+    #[test]
+    fn empty_histogram_is_zero() {
+        let h = SignedHistogram::default();
+        assert!(h.is_empty());
+        assert_eq!(h.mean(), 0.0);
+        assert_eq!(h.stdev(), 0.0);
+        for p in [0.0, 50.0, 100.0] {
+            assert_eq!(h.value_at_percentile(p), 0.0, "p{p}");
+        }
+    }
+
+    /// A single value (positive, negative, zero): mean is the value, stdev is 0,
+    /// and every percentile is the value. Magnitudes are unit-resolution so the
+    /// expected results are exact.
+    #[test]
+    fn single_value() {
+        for &v in &[7i64, -7, 0] {
+            let mut h = SignedHistogram::default();
+            record(&mut h, v);
+            assert_eq!(h.len(), 1);
+            assert_eq!(h.mean(), v as f64, "mean v={v}");
+            assert_eq!(h.stdev(), 0.0, "stdev v={v}");
+            for p in [0.0, 50.0, 100.0] {
+                assert_eq!(h.value_at_percentile(p), v as f64, "v={v} p={p}");
+            }
+        }
+    }
+
+    /// mean and stdev on asymmetric mixed-sign data vs an independent oracle —
+    /// the only check of the cross-store combine where a sign error or wrong
+    /// second moment would surface. hdr's stdev is population (÷n), as is the
+    /// oracle; unit-resolution magnitudes leave only rounding.
+    #[test]
+    fn mean_stdev_match_oracle_on_asymmetric_signed_data() {
+        let data: [i64; 7] = [-3, -3, -1, 2, 5, 5, 5];
+        let mut hist = SignedHistogram::default();
+        for &v in &data {
+            record(&mut hist, v);
+        }
+        let n = data.len() as f64;
+        let mean = data.iter().map(|&v| v as f64).sum::<f64>() / n;
+        let variance = data.iter().map(|&v| (v as f64 - mean).powi(2)).sum::<f64>() / n;
+        assert!(
+            approx_eq(hist.mean(), mean),
+            "mean: {} vs {mean}",
+            hist.mean(),
+        );
+        assert!(
+            approx_eq(hist.stdev(), variance.sqrt()),
+            "stdev: {} vs {}",
+            hist.stdev(),
+            variance.sqrt(),
+        );
+    }
+}

--- a/src/stats/timeseries.rs
+++ b/src/stats/timeseries.rs
@@ -235,6 +235,25 @@ mod test {
         assert_le!(estimator.effective_sample_size(), N);
     }
 
+    /// The effective sample size is built from ratios of variances, so it must
+    /// not depend on the unit the values are expressed in.
+    #[test]
+    fn test_ess_scale_invariant() {
+        let mut rng = SmallRng::seed_from_u64(1);
+        let mut raw = TimeSeriesStats::default();
+        let mut scaled = TimeSeriesStats::default();
+        for _ in 0..200 {
+            let v = rng.random::<f64>();
+            for _ in 0..16 {
+                raw.record(v, 1.0);
+                scaled.record(v * 1e9, 1.0);
+            }
+        }
+        let ess_raw = raw.effective_sample_size() as f64;
+        let ess_scaled = scaled.effective_sample_size() as f64;
+        assert_approx_eq!(ess_raw, ess_scaled, ess_raw * 0.01 + 1.0);
+    }
+
     #[rstest]
     #[case(100, 2)]
     #[case(100, 4)]

--- a/src/stats/value.rs
+++ b/src/stats/value.rs
@@ -1,0 +1,246 @@
+use crate::stats::histogram::SerializableHistogram;
+use crate::stats::percentiles::Percentiles;
+use crate::stats::signed_histogram::SignedHistogram;
+use crate::stats::timeseries::TimeSeriesStats;
+use crate::stats::Mean;
+use serde::{Deserialize, Serialize};
+
+/// A dimensionless metric value.
+/// Stored with 1e-6 resolution; zero is stored exactly and negative values
+/// are stored as magnitudes in a separate histogram.
+/// Values must be finite — the recording API (`record_metric`) rejects
+/// everything else before it gets here.
+#[derive(Copy, Clone, Debug)]
+pub struct MetricValue(pub f64);
+
+impl MetricValue {
+    /// Histogram units per metric point: values are stored in 1e-6 units,
+    /// giving 6 significant decimal digits.
+    const STORED_PER_POINT: f64 = 1e6;
+    /// Scale from integer histogram units back to reported numbers.
+    const DISPLAY_SCALE: f64 = 1.0 / Self::STORED_PER_POINT;
+
+    /// Magnitude in integer histogram units, exactly where possible.
+    fn magnitude_stored(self) -> u64 {
+        debug_assert!(self.0.is_finite());
+        (self.0.abs() * Self::STORED_PER_POINT)
+            .round()
+            .min(u64::MAX as f64) as u64
+    }
+
+    /// Signed value in histogram units for time-series statistics,
+    /// which are scale-invariant.
+    fn stored_f64(self) -> f64 {
+        self.0 * Self::STORED_PER_POINT
+    }
+}
+
+/// Captures the mean and percentiles of a signed distribution,
+/// with uncertainty estimates.
+/// Negative values live in a separate histogram holding their magnitudes.
+#[derive(Serialize, Deserialize, Debug)]
+pub struct ValueDistribution {
+    pub mean: Mean,
+    pub percentiles: Percentiles,
+    /// Non-negative recorded values, zero included.
+    pub histogram: SerializableHistogram,
+    /// Magnitudes of negative recorded values.
+    /// Omitted from reports while empty, so reports of metrics that never
+    /// went negative keep their shape; reports without it load as empty.
+    #[serde(default, skip_serializing_if = "SerializableHistogram::is_empty")]
+    pub negative_histogram: SerializableHistogram,
+}
+
+/// Builds ValueDistribution from a stream of measured values.
+#[derive(Clone, Debug, Default)]
+pub struct ValueDistributionRecorder {
+    histogram: SignedHistogram,
+    ess_estimator: TimeSeriesStats,
+}
+
+impl ValueDistributionRecorder {
+    pub fn record(&mut self, value: MetricValue) {
+        let magnitude = value.magnitude_stored();
+        // A magnitude that rounds to zero is zero at our resolution, so it
+        // belongs in the non-negative store regardless of its sign.
+        let negative = value.0 < 0.0 && magnitude > 0;
+        self.histogram.record(magnitude, negative).unwrap();
+        self.ess_estimator.record(value.stored_f64(), 1.0);
+    }
+
+    pub fn add(&mut self, other: &ValueDistributionRecorder) {
+        self.histogram.add(&other.histogram).unwrap();
+        self.ess_estimator.add(&other.ess_estimator);
+    }
+
+    pub fn clear(&mut self) {
+        self.histogram.clear();
+        self.ess_estimator.clear();
+    }
+
+    pub fn distribution(&self) -> ValueDistribution {
+        ValueDistribution {
+            mean: self.mean(1),
+            percentiles: Percentiles::compute(&self.histogram, MetricValue::DISPLAY_SCALE),
+            histogram: SerializableHistogram(self.histogram.positive().clone()),
+            negative_histogram: SerializableHistogram(self.histogram.negative().clone()),
+        }
+    }
+
+    pub fn distribution_with_errors(&self) -> ValueDistribution {
+        let ess = self.ess_estimator.effective_sample_size();
+        ValueDistribution {
+            mean: self.mean(ess),
+            percentiles: Percentiles::compute_with_errors(
+                &self.histogram,
+                MetricValue::DISPLAY_SCALE,
+                ess,
+            ),
+            histogram: SerializableHistogram(self.histogram.positive().clone()),
+            negative_histogram: SerializableHistogram(self.histogram.negative().clone()),
+        }
+    }
+
+    fn mean(&self, effective_n: u64) -> Mean {
+        let scale = MetricValue::DISPLAY_SCALE;
+        Mean {
+            n: effective_n,
+            value: self.histogram.mean() * scale,
+            std_err: if effective_n > 1 {
+                Some(self.histogram.stdev() * scale / (effective_n as f64 - 1.0).sqrt())
+            } else {
+                None
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::stats::percentiles::Percentile;
+
+    #[test]
+    fn stores_zero_exactly() {
+        let mut recorder = ValueDistributionRecorder::default();
+        recorder.record(MetricValue(0.0));
+        recorder.record(MetricValue(0.0));
+        let dist = recorder.distribution();
+        assert_eq!(dist.mean.value, 0.0);
+        assert_eq!(dist.percentiles.get(Percentile::P50).value, 0.0);
+        assert_eq!(dist.percentiles.get(Percentile::Max).value, 0.0);
+    }
+
+    #[test]
+    fn records_and_computes_distribution() {
+        let mut recorder = ValueDistributionRecorder::default();
+        recorder.record(MetricValue(0.5));
+        recorder.record(MetricValue(1.0));
+        let dist = recorder.distribution();
+        assert!((dist.mean.value - 0.75).abs() < 0.001);
+    }
+
+    #[test]
+    fn merges_recorders() {
+        let mut a = ValueDistributionRecorder::default();
+        let mut b = ValueDistributionRecorder::default();
+        a.record(MetricValue(0.2));
+        b.record(MetricValue(0.8));
+        a.add(&b);
+        let dist = a.distribution();
+        assert!((dist.mean.value - 0.5).abs() < 0.001);
+    }
+
+    #[test]
+    fn merges_recorders_with_negative_values() {
+        let mut a = ValueDistributionRecorder::default();
+        let mut b = ValueDistributionRecorder::default();
+        a.record(MetricValue(-0.2));
+        a.record(MetricValue(0.4));
+        b.record(MetricValue(-0.6));
+        a.add(&b);
+        let dist = a.distribution();
+        assert!((dist.mean.value + 0.1333).abs() < 0.001);
+        assert!(!dist.negative_histogram.is_empty());
+    }
+
+    #[test]
+    fn records_negative_values() {
+        let mut recorder = ValueDistributionRecorder::default();
+        for v in [-2.0, -1.0, 0.0, 1.0, 2.0] {
+            recorder.record(MetricValue(v));
+        }
+        let dist = recorder.distribution();
+        assert!(dist.mean.value.abs() < 1e-6);
+        assert!((dist.percentiles.get(Percentile::Min).value + 2.0).abs() < 0.01);
+        assert!(dist.percentiles.get(Percentile::P50).value.abs() < 1e-6);
+        assert!((dist.percentiles.get(Percentile::Max).value - 2.0).abs() < 0.01);
+        assert!(!dist.negative_histogram.is_empty());
+    }
+
+    #[test]
+    fn records_all_negative_distribution() {
+        let mut recorder = ValueDistributionRecorder::default();
+        for v in [-3.0, -2.0, -1.0] {
+            recorder.record(MetricValue(v));
+        }
+        let dist = recorder.distribution();
+        assert!((dist.mean.value + 2.0).abs() < 0.01);
+        assert!((dist.percentiles.get(Percentile::Min).value + 3.0).abs() < 0.01);
+        assert!((dist.percentiles.get(Percentile::P50).value + 2.0).abs() < 0.01);
+        assert!((dist.percentiles.get(Percentile::Max).value + 1.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn survives_serde_roundtrip() {
+        let mut recorder = ValueDistributionRecorder::default();
+        recorder.record(MetricValue(0.9933));
+        let json = serde_json::to_string(&recorder.distribution()).unwrap();
+        let parsed: ValueDistribution = serde_json::from_str(&json).unwrap();
+        assert!((parsed.mean.value - 0.9933).abs() < 0.001);
+    }
+
+    #[test]
+    fn positive_only_omits_negative_histogram_in_json() {
+        let mut recorder = ValueDistributionRecorder::default();
+        recorder.record(MetricValue(0.5));
+        let json = serde_json::to_string(&recorder.distribution()).unwrap();
+        assert!(!json.contains("negative_histogram"));
+        let parsed: ValueDistribution = serde_json::from_str(&json).unwrap();
+        assert!(parsed.negative_histogram.is_empty());
+    }
+
+    #[test]
+    fn negative_values_survive_serde_roundtrip() {
+        let mut recorder = ValueDistributionRecorder::default();
+        recorder.record(MetricValue(-0.25));
+        recorder.record(MetricValue(0.75));
+        let dist = recorder.distribution();
+        let json = serde_json::to_string(&dist).unwrap();
+        let parsed: ValueDistribution = serde_json::from_str(&json).unwrap();
+        assert!((parsed.mean.value - 0.25).abs() < 0.001);
+        assert!(!parsed.negative_histogram.is_empty());
+        for p in [Percentile::Min, Percentile::P50, Percentile::Max] {
+            assert!((parsed.percentiles.get(p).value - dist.percentiles.get(p).value).abs() < 1e-9);
+        }
+    }
+
+    /// The zero-routing invariant: a negative value whose magnitude rounds to 0
+    /// is zero at our 1e-6 resolution, so it goes to the non-negative store, not
+    /// the negative one. Pins the exact boundary against the resolution floor.
+    #[test]
+    fn tiny_negative_routes_to_positive_store() {
+        // |magnitude| = round(-1e-9 * 1e6) = round(-0.001) = 0 -> positive store.
+        let mut r = ValueDistributionRecorder::default();
+        r.record(MetricValue(-1e-9));
+        assert!(r.histogram.negative().is_empty());
+        assert_eq!(r.histogram.positive().len(), 1);
+        assert_eq!(r.distribution().mean.value, 0.0);
+
+        // |magnitude| = round(-1e-6 * 1e6) = round(-1.0) = 1 -> negative store.
+        let mut r2 = ValueDistributionRecorder::default();
+        r2.record(MetricValue(-1e-6));
+        assert_eq!(r2.histogram.negative().len(), 1);
+        assert!(r2.histogram.positive().is_empty());
+    }
+}


### PR DESCRIPTION
Workload scripts could not get computed values (e.g. ANN search recall) or run context into benchmark reports.

- set_report_field(key, value): run metadata
- record_metric(name, value): per-cycle metrics, aggregated like latencies (mean, std_err, percentiles)
- declare_metric(name, "higher"/"lower"): metric direction
- latte show -b: Welch's t-test significance for custom metrics

Latency histogram machinery generalized to DistributionRecorder<T>; report format unchanged, older reports still load (follow-up to #181).

Fixes QATOOLS-243