### PR TITLE
Support reading binary data files in workload scripts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2345,6 +2345,7 @@ dependencies = [
  "serde_json",
  "status-line",
  "strum",
+ "tempfile",
  "testcontainers",
  "thiserror 2.0.18",
  "time",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,6 +81,7 @@ cargo-lock = "11.0.0"
 
 [dev-dependencies]
 assert_approx_eq = "1"
+tempfile = "3"
 rstest = "0.22"
 tokio = { version = "1.52.1", features = ["rt", "test-util", "macros"] }
 testcontainers = "0.27"

--- a/README.md
+++ b/README.md
@@ -453,6 +453,71 @@ pub async fn prepare(ctx) {
 ...
 ```
 
+#### Binary files
+
+Fixed-record binary files can be read with `fs::open_binary`, which returns a
+handle supporting positioned, typed reads. Every typed read takes the byte
+order as its first argument: `fs::LE` (little-endian) or `fs::BE`
+(big-endian):
+
+- `fs::open_binary(file_path)` – opens a binary file for reading
+- `f.len()` – file size in bytes
+- `f.seek(offset)` – moves the read position to an absolute byte offset
+- `f.seek_relative(delta)` – moves the read position relative to the current
+  one (negative moves backwards); the resulting position must stay inside
+  the file
+- `f.read_u32(order)`, `f.read_i32(order)`, `f.read_i64(order)` – reads one
+  integer
+- `f.read_f32(order)`, `f.read_f64(order)` – reads one float
+- `f.read_u32_vec(order, count)`, `f.read_i32_vec(order, count)`,
+  `f.read_i64_vec(order, count)`, `f.read_f32_vec(order, count)`,
+  `f.read_f64_vec(order, count)` – reads
+  `count` values into a vector in one buffered read (preferred for reading
+  a whole record)
+
+Reads advance the position; reading past end-of-file returns an error. Since
+`seek` allows computing a record's offset directly, large files can be read
+record by record instead of being loaded into memory up front.
+
+An open file handle cannot be stored in `ctx.data` by `prepare`: user data is
+passed through serialization when the context is cloned for each worker
+thread, and open files are not serializable. Read everything you need in
+`prepare`, or open a per-worker handle in `prepare_worker`:
+
+```rust
+pub async fn prepare(ctx) {
+    let f = fs::open_binary(DATAFILE)?;
+    // example header: record count and per-record element count, as two u32
+    // (8 bytes total - the records start at offset 8)
+    ctx.data.count = f.read_u32(fs::LE)?;
+    ctx.data.record_len = f.read_u32(fs::LE)?;
+}
+
+pub async fn prepare_worker(ctx) {
+    ctx.data.file = fs::open_binary(DATAFILE)?;
+}
+
+pub async fn run(ctx, i) {
+    let record_idx = i % ctx.data.count;
+    ctx.data.file.seek(8 + record_idx * ctx.data.record_len * 4)?;
+    let record = ctx.data.file.read_f32_vec(fs::LE, ctx.data.record_len)?;
+    // ... use record in queries
+}
+```
+
+Concurrent cycles of a worker share its file handle. File calls never yield,
+so a seek and the reads that depend on it are safe as long as no `await` sits
+between them. Keep such sequences together, or wrap them in a non-async
+helper function. This makes an accidental `await` impossible.
+
+```rust
+// Broken under concurrency: the await yields, so another cycle
+// may move the shared position between the seek and the read.
+ctx.data.file.seek(8 + idx * RECORD_BYTES)?;
+let category = ctx.execute_prepared(CATEGORY, [idx]).await?;
+let record = ctx.data.file.read_f32_vec(fs::LE, LEN)?;  // wrong record
+```
+
 ### Parameterizing workloads
 
 Workloads can be parameterized by parameters given from the command line invocation.

--- a/README.md
+++ b/README.md
@@ -474,6 +474,10 @@ order as its first argument: `fs::LE` (little-endian) or `fs::BE`
   `f.read_f64_vec(order, count)` – reads
   `count` values into a vector in one buffered read (preferred for reading
   a whole record)
+- `f.read_bytes(count)` – reads `count` raw bytes into a byte string. A byte
+  string holding packed little-endian f32 values can be bound directly to a
+  CQL `vector<float, N>` parameter - this avoids the per-element value
+  representation entirely, which matters for large in-memory datasets
 
 Reads advance the position; reading past end-of-file returns an error. Since
 `seek` allows computing a record's offset directly, large files can be read

--- a/README.md
+++ b/README.md
@@ -323,6 +323,12 @@ We do:
 - Define required `schema` function as shown above
 - Define optional `prepare` function which runs once before the latte workload and useful
   for setting and pre-calculating things needed to be done once for whole workload.
+- Define optional `prepare_worker` function which runs once on each worker thread's copy
+  of the context, after `prepare` and before the first cycle. Worker threads receive
+  `ctx.data` as a serialized copy, so state that cannot be serialized - such as open
+  file handles - must be created here instead of in `prepare`. The context exposes
+  `ctx.worker_id` (0-based) and `ctx.worker_count`, so workers can partition work
+  among themselves without overlaps.
 - Define any public-facing rune function (name must not overlap with the reserved ones).
   - If we plan to have just 1 rune function, we can call it `run` and avoid specifying the `-f` parameter.
   - If we plan to have 2+ rune functions then we use the `-f / --function ` latte parameter.

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,14 +2,14 @@ use crate::scripting::db_error::DbError;
 use hdrhistogram::serialization::interval_log::IntervalLogWriterError;
 use hdrhistogram::serialization::V2DeflateSerializeError;
 use rune::alloc;
-use rune::runtime::{AccessError, RuntimeError, VmError};
+use rune::runtime::{AccessError, Object, RuntimeError, Value, VmError};
 use std::path::PathBuf;
 use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum LatteError {
     #[error("Context data could not be serialized: {0}")]
-    ContextDataEncode(#[from] rmp_serde::encode::Error),
+    ContextDataEncode(String),
 
     #[error("Context data could not be deserialized: {0}")]
     ContextDataDecode(#[from] rmp_serde::decode::Error),
@@ -72,6 +72,33 @@ impl From<Box<DbError>> for LatteError {
     }
 }
 
-impl LatteError {}
+impl LatteError {
+    /// Builds the context-data serialization error, naming the top-level
+    /// `data` entries that fail to serialize - rune's serializer reports no
+    /// path information, so without this the user cannot tell which value is
+    /// at fault.
+    pub fn context_data_encode(data: &Value, cause: &rmp_serde::encode::Error) -> Self {
+        let offenders = unserializable_keys(data);
+        let what = if offenders.is_empty() {
+            cause.to_string()
+        } else {
+            format!("{} - {cause}", offenders.join(", "))
+        };
+        LatteError::ContextDataEncode(format!("{what}. Data may only hold plain values"))
+    }
+}
+
+/// Names the top-level `data` entries that cannot be serialized. Serializes
+/// into a sink because entries can be huge (e.g. a packed dataset) and only
+/// the verdict is needed, not the output.
+fn unserializable_keys(data: &Value) -> Vec<String> {
+    let Ok(obj) = data.borrow_ref::<Object>() else {
+        return Vec::new();
+    };
+    obj.iter()
+        .filter(|(_, v)| rmp_serde::encode::write(&mut std::io::sink(), v).is_err())
+        .map(|(k, _)| format!("data.{k}"))
+        .collect()
+}
 
 pub type Result<T> = std::result::Result<T, LatteError>;

--- a/src/exec/mod.rs
+++ b/src/exec/mod.rs
@@ -324,14 +324,18 @@ pub async fn par_execute(
     let mut streams = Vec::with_capacity(thread_count);
     let mut stats = Recorder::start(rate, concurrency, keep_log, hdrh_writer);
 
-    for _ in 0..thread_count {
+    for worker_id in 0..thread_count {
+        let mut worker = workload.clone()?;
+        worker
+            .prepare_worker(worker_id as u64, thread_count as u64)
+            .await?;
         let s = spawn_stream(
             concurrency,
             rate.map(|r| r / (thread_count as f64)),
             rate_sine_amplitude,
             rate_sine_frequency,
             sampling,
-            workload.clone()?,
+            worker,
             deadline.share(),
             progress.clone(),
         );

--- a/src/exec/workload.rs
+++ b/src/exec/workload.rs
@@ -73,6 +73,7 @@ impl FnRef {
 
 pub const SCHEMA_FN: &str = "schema";
 pub const PREPARE_FN: &str = "prepare";
+pub const PREPARE_WORKER_FN: &str = "prepare_worker";
 pub const ERASE_FN: &str = "erase";
 pub const LOAD_FN: &str = "load";
 
@@ -218,6 +219,10 @@ impl Program {
         self.has_function(&FnRef::new(PREPARE_FN))
     }
 
+    pub fn has_prepare_worker(&self) -> bool {
+        self.has_function(&FnRef::new(PREPARE_WORKER_FN))
+    }
+
     pub fn has_schema(&self) -> bool {
         self.has_function(&FnRef::new(SCHEMA_FN))
     }
@@ -240,6 +245,18 @@ impl Program {
     pub async fn prepare(&mut self, context: &Context) -> Result<(), LatteError> {
         let context = SessionRef::new(context);
         self.async_call(&FnRef::new(PREPARE_FN), (context,)).await?;
+        Ok(())
+    }
+
+    /// Calls the script's `prepare_worker` function.
+    /// Called once on each worker's clone of the context, before its first
+    /// cycle. Typically used to create per-worker state that cannot be passed
+    /// from `prepare` through the serialized clone of `data`, such as open
+    /// file handles.
+    pub async fn prepare_worker(&mut self, context: &Context) -> Result<(), LatteError> {
+        let context = SessionRef::new(context);
+        self.async_call(&FnRef::new(PREPARE_WORKER_FN), (context,))
+            .await?;
         Ok(())
     }
 
@@ -412,6 +429,25 @@ impl Workload {
                 self.state.try_lock().unwrap().functions(),
             )),
         })
+    }
+
+    /// Runs the script's optional `prepare_worker` function on this
+    /// workload's context. Called on each worker clone before its first
+    /// cycle.
+    pub async fn prepare_worker(
+        &mut self,
+        worker_id: u64,
+        worker_count: u64,
+    ) -> Result<(), LatteError> {
+        self.context.worker_id = worker_id;
+        self.context.worker_count = worker_count;
+        if self.program.has_prepare_worker() {
+            self.context.in_prepare_worker = true;
+            let result = self.program.prepare_worker(&self.context).await;
+            self.context.in_prepare_worker = false;
+            result?;
+        }
+        Ok(())
     }
 
     /// Executes a single cycle of a workload.

--- a/src/scripting/alternator/context.rs
+++ b/src/scripting/alternator/context.rs
@@ -30,6 +30,17 @@ pub struct Context {
     /// Run-level state written through such a copy (report metadata, metric
     /// orientations) is never merged back, so the scripting API rejects those calls.
     pub is_worker_clone: bool,
+    /// True while the script's `prepare_worker` function runs on this context.
+    /// Per-cycle stats written during it (e.g. metrics) are cleared before the
+    /// run starts, so the scripting API rejects those calls.
+    pub in_prepare_worker: bool,
+    /// 0-based index of this worker among `worker_count` workers; 0 on the
+    /// main context used by setup functions.
+    #[rune(get, copy)]
+    pub worker_id: u64,
+    /// Number of worker threads in the run; 1 on the main context.
+    #[rune(get, copy)]
+    pub worker_count: u64,
     #[rune(get)]
     pub data: Value,
 }
@@ -58,6 +69,9 @@ impl Context {
             partition_row_presets: Arc::new(TryLock::new(HashMap::new())),
             load_cycle_count: 0,
             is_worker_clone: false,
+            in_prepare_worker: false,
+            worker_id: 0,
+            worker_count: 1,
             data: Value::new(Object::new()).unwrap(),
         }
     }
@@ -84,6 +98,9 @@ impl Context {
             )),
             load_cycle_count: self.load_cycle_count,
             is_worker_clone: true,
+            in_prepare_worker: false,
+            worker_id: self.worker_id,
+            worker_count: self.worker_count,
             data: deserialized,
         })
     }
@@ -104,6 +121,9 @@ impl Context {
             partition_row_presets: Arc::clone(&self.partition_row_presets),
             load_cycle_count: self.load_cycle_count,
             is_worker_clone: self.is_worker_clone,
+            in_prepare_worker: self.in_prepare_worker,
+            worker_id: self.worker_id,
+            worker_count: self.worker_count,
             data: self.data.clone(),
         }
     }

--- a/src/scripting/alternator/context.rs
+++ b/src/scripting/alternator/context.rs
@@ -77,7 +77,8 @@ impl Context {
     }
 
     pub fn clone(&self) -> Result<Self, LatteError> {
-        let serialized = rmp_serde::to_vec(&self.data)?;
+        let serialized = rmp_serde::to_vec(&self.data)
+            .map_err(|e| LatteError::context_data_encode(&self.data, &e))?;
         let deserialized: Value = rmp_serde::from_slice(&serialized)?;
         Ok(Context {
             client: self.client.clone(),

--- a/src/scripting/binary_file.rs
+++ b/src/scripting/binary_file.rs
@@ -1,4 +1,4 @@
-use rune::runtime::{Mut, Ref};
+use rune::runtime::{Bytes, Mut, Ref};
 use rune::Any;
 use std::fs::File;
 use std::io;
@@ -199,6 +199,10 @@ impl BinaryFile {
             .collect())
     }
 
+    pub fn read_bytes(&mut self, count: i64) -> io::Result<Vec<u8>> {
+        self.read_bulk(count, 1, "read_bytes")
+    }
+
     fn read_array<const N: usize>(&mut self) -> io::Result<[u8; N]> {
         let mut buf = [0u8; N];
         self.reader.read_exact(&mut buf)?;
@@ -338,6 +342,16 @@ pub fn read_i64_vec(
     count: i64,
 ) -> io::Result<Vec<i64>> {
     BinaryFile::read_i64_vec(&mut file, ByteOrder::parse(&order)?, count)
+}
+
+/// Reads `count` raw bytes into a byte string, with no interpretation of the
+/// contents. Keeping fixed-size records as raw bytes instead of value vectors
+/// avoids per-element overhead.
+#[rune::function(instance)]
+pub fn read_bytes(mut file: Mut<BinaryFile>, count: i64) -> io::Result<Bytes> {
+    let buf = BinaryFile::read_bytes(&mut file, count)?;
+    // Adopts the Vec allocation instead of copying the bytes.
+    Bytes::try_from(buf).map_err(|e| io::Error::new(io::ErrorKind::OutOfMemory, e.to_string()))
 }
 
 #[cfg(test)]
@@ -550,6 +564,17 @@ mod tests {
         assert_eq!(err.kind(), io::ErrorKind::UnexpectedEof);
         let err = f.read_f32_vec(LE, 5).unwrap_err();
         assert_eq!(err.kind(), io::ErrorKind::UnexpectedEof);
+    }
+
+    #[test]
+    fn reads_raw_bytes() {
+        let tmp = write_temp(&[1, 2, 3, 4, 5]);
+        let mut f = open(&tmp);
+        assert_eq!(f.read_bytes(4).unwrap(), vec![1, 2, 3, 4]);
+        assert_eq!(
+            f.read_bytes(2).unwrap_err().kind(),
+            io::ErrorKind::UnexpectedEof
+        );
     }
 
     #[test]

--- a/src/scripting/binary_file.rs
+++ b/src/scripting/binary_file.rs
@@ -1,0 +1,563 @@
+use rune::runtime::{Mut, Ref};
+use rune::Any;
+use std::fs::File;
+use std::io;
+use std::io::{BufReader, Read, Seek, SeekFrom};
+
+/// Byte order for typed reads, selected per call with the `fs::LE` / `fs::BE`
+/// constants.
+#[derive(Clone, Copy, Debug)]
+pub enum ByteOrder {
+    Le,
+    Be,
+}
+
+impl ByteOrder {
+    fn parse(order: &str) -> io::Result<ByteOrder> {
+        if order.eq_ignore_ascii_case("le") {
+            Ok(ByteOrder::Le)
+        } else if order.eq_ignore_ascii_case("be") {
+            Ok(ByteOrder::Be)
+        } else {
+            Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("byte order must be fs::LE (\"le\") or fs::BE (\"be\"), got \"{order}\""),
+            ))
+        }
+    }
+}
+
+/// A binary file opened for reading typed values (scalars and arrays, in the
+/// byte order given per call) at arbitrary offsets. Enables workloads to read
+/// fixed-record binary data files without loading them into memory. First
+/// `seek` to a record's offset, then read its fields. Reads are buffered and
+/// advance the position. Hitting end-of-file surfaces as an `UnexpectedEof`
+/// error.
+#[derive(Any, Debug)]
+pub struct BinaryFile {
+    reader: BufReader<File>,
+    len: u64,
+}
+
+#[allow(clippy::len_without_is_empty)]
+impl BinaryFile {
+    pub fn new(path: &str) -> io::Result<Self> {
+        let file = File::open(path)
+            .map_err(|e| io::Error::new(e.kind(), format!("Failed to open file {path}: {e}")))?;
+        let len = file.metadata()?.len();
+        Ok(BinaryFile {
+            reader: BufReader::new(file),
+            len,
+        })
+    }
+
+    pub fn len(&self) -> i64 {
+        self.len as i64
+    }
+
+    pub fn seek(&mut self, offset: i64) -> io::Result<()> {
+        let offset: u64 = offset.try_into().map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("seek: offset must be non-negative, got {offset}"),
+            )
+        })?;
+        if offset > self.len {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!(
+                    "seek: offset {offset} is beyond the file length {}",
+                    self.len
+                ),
+            ));
+        }
+        self.reader.seek(SeekFrom::Start(offset))?;
+        Ok(())
+    }
+
+    pub fn seek_relative(&mut self, delta: i64) -> io::Result<()> {
+        let target = self.reader.stream_position()? as i128 + delta as i128;
+        if target < 0 || target > self.len as i128 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!(
+                    "seek_relative: target position {target} is outside the file (length {})",
+                    self.len
+                ),
+            ));
+        }
+        self.reader.seek_relative(delta)
+    }
+
+    pub fn read_u32(&mut self, order: ByteOrder) -> io::Result<i64> {
+        let b = self.read_array()?;
+        Ok(match order {
+            ByteOrder::Le => u32::from_le_bytes(b),
+            ByteOrder::Be => u32::from_be_bytes(b),
+        } as i64)
+    }
+
+    pub fn read_i32(&mut self, order: ByteOrder) -> io::Result<i64> {
+        let b = self.read_array()?;
+        Ok(match order {
+            ByteOrder::Le => i32::from_le_bytes(b),
+            ByteOrder::Be => i32::from_be_bytes(b),
+        } as i64)
+    }
+
+    pub fn read_i64(&mut self, order: ByteOrder) -> io::Result<i64> {
+        let b = self.read_array()?;
+        Ok(match order {
+            ByteOrder::Le => i64::from_le_bytes(b),
+            ByteOrder::Be => i64::from_be_bytes(b),
+        })
+    }
+
+    pub fn read_f32(&mut self, order: ByteOrder) -> io::Result<f64> {
+        let b = self.read_array()?;
+        Ok(match order {
+            ByteOrder::Le => f32::from_le_bytes(b),
+            ByteOrder::Be => f32::from_be_bytes(b),
+        } as f64)
+    }
+
+    pub fn read_f64(&mut self, order: ByteOrder) -> io::Result<f64> {
+        let b = self.read_array()?;
+        Ok(match order {
+            ByteOrder::Le => f64::from_le_bytes(b),
+            ByteOrder::Be => f64::from_be_bytes(b),
+        })
+    }
+
+    pub fn read_f32_vec(&mut self, order: ByteOrder, count: i64) -> io::Result<Vec<f64>> {
+        let buf = self.read_bulk(count, 4, "read_f32_vec")?;
+        Ok(buf
+            .chunks_exact(4)
+            .map(|c| {
+                let b = c.try_into().unwrap();
+                (match order {
+                    ByteOrder::Le => f32::from_le_bytes(b),
+                    ByteOrder::Be => f32::from_be_bytes(b),
+                }) as f64
+            })
+            .collect())
+    }
+
+    pub fn read_u32_vec(&mut self, order: ByteOrder, count: i64) -> io::Result<Vec<i64>> {
+        let buf = self.read_bulk(count, 4, "read_u32_vec")?;
+        Ok(buf
+            .chunks_exact(4)
+            .map(|c| {
+                let b = c.try_into().unwrap();
+                (match order {
+                    ByteOrder::Le => u32::from_le_bytes(b),
+                    ByteOrder::Be => u32::from_be_bytes(b),
+                }) as i64
+            })
+            .collect())
+    }
+
+    pub fn read_f64_vec(&mut self, order: ByteOrder, count: i64) -> io::Result<Vec<f64>> {
+        let buf = self.read_bulk(count, 8, "read_f64_vec")?;
+        Ok(buf
+            .chunks_exact(8)
+            .map(|c| {
+                let b = c.try_into().unwrap();
+                match order {
+                    ByteOrder::Le => f64::from_le_bytes(b),
+                    ByteOrder::Be => f64::from_be_bytes(b),
+                }
+            })
+            .collect())
+    }
+
+    pub fn read_i32_vec(&mut self, order: ByteOrder, count: i64) -> io::Result<Vec<i64>> {
+        let buf = self.read_bulk(count, 4, "read_i32_vec")?;
+        Ok(buf
+            .chunks_exact(4)
+            .map(|c| {
+                let b = c.try_into().unwrap();
+                (match order {
+                    ByteOrder::Le => i32::from_le_bytes(b),
+                    ByteOrder::Be => i32::from_be_bytes(b),
+                }) as i64
+            })
+            .collect())
+    }
+
+    pub fn read_i64_vec(&mut self, order: ByteOrder, count: i64) -> io::Result<Vec<i64>> {
+        let buf = self.read_bulk(count, 8, "read_i64_vec")?;
+        Ok(buf
+            .chunks_exact(8)
+            .map(|c| {
+                let b = c.try_into().unwrap();
+                match order {
+                    ByteOrder::Le => i64::from_le_bytes(b),
+                    ByteOrder::Be => i64::from_be_bytes(b),
+                }
+            })
+            .collect())
+    }
+
+    fn read_array<const N: usize>(&mut self) -> io::Result<[u8; N]> {
+        let mut buf = [0u8; N];
+        self.reader.read_exact(&mut buf)?;
+        Ok(buf)
+    }
+
+    fn read_bulk(&mut self, count: i64, elem_size: usize, what: &str) -> io::Result<Vec<u8>> {
+        let count: usize = count.try_into().map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("{what}: element count must be non-negative, got {count}"),
+            )
+        })?;
+        let bytes = count.checked_mul(elem_size).ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("{what}: element count {count} is too large"),
+            )
+        })?;
+        let remaining = self.len.saturating_sub(self.reader.stream_position()?);
+        if bytes as u64 > remaining {
+            return Err(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                format!("{what}: requested {bytes} bytes but only {remaining} remain in the file"),
+            ));
+        }
+        let mut buf = vec![0u8; bytes];
+        self.reader.read_exact(&mut buf)?;
+        Ok(buf)
+    }
+}
+
+/// Opens a binary file for reading. Returns a `BinaryFile` positioned at the
+/// start of the file.
+#[rune::function]
+pub fn open_binary(path: &str) -> io::Result<BinaryFile> {
+    BinaryFile::new(path)
+}
+
+/// Returns the file size in bytes.
+#[rune::function(instance)]
+pub fn len(file: Mut<BinaryFile>) -> i64 {
+    file.len()
+}
+
+/// Moves the read position to an absolute byte offset from the start of the
+/// file. The offset must lie within `0..=len`.
+#[rune::function(instance)]
+pub fn seek(mut file: Mut<BinaryFile>, offset: i64) -> io::Result<()> {
+    BinaryFile::seek(&mut file, offset)
+}
+
+/// Moves the read position by the given number of bytes relative to the
+/// current position (negative moves backwards). The resulting position must
+/// lie within `0..=len`.
+#[rune::function(instance)]
+pub fn seek_relative(mut file: Mut<BinaryFile>, delta: i64) -> io::Result<()> {
+    BinaryFile::seek_relative(&mut file, delta)
+}
+
+/// Reads an unsigned 32-bit integer.
+#[rune::function(instance)]
+pub fn read_u32(mut file: Mut<BinaryFile>, order: Ref<str>) -> io::Result<i64> {
+    BinaryFile::read_u32(&mut file, ByteOrder::parse(&order)?)
+}
+
+/// Reads a signed 32-bit integer.
+#[rune::function(instance)]
+pub fn read_i32(mut file: Mut<BinaryFile>, order: Ref<str>) -> io::Result<i64> {
+    BinaryFile::read_i32(&mut file, ByteOrder::parse(&order)?)
+}
+
+/// Reads a signed 64-bit integer.
+#[rune::function(instance)]
+pub fn read_i64(mut file: Mut<BinaryFile>, order: Ref<str>) -> io::Result<i64> {
+    BinaryFile::read_i64(&mut file, ByteOrder::parse(&order)?)
+}
+
+/// Reads a 32-bit float.
+#[rune::function(instance)]
+pub fn read_f32(mut file: Mut<BinaryFile>, order: Ref<str>) -> io::Result<f64> {
+    BinaryFile::read_f32(&mut file, ByteOrder::parse(&order)?)
+}
+
+/// Reads a 64-bit float.
+#[rune::function(instance)]
+pub fn read_f64(mut file: Mut<BinaryFile>, order: Ref<str>) -> io::Result<f64> {
+    BinaryFile::read_f64(&mut file, ByteOrder::parse(&order)?)
+}
+
+/// Reads `count` 32-bit floats into a vector in one buffered read. This is
+/// the preferred way to read a whole fixed-size record.
+#[rune::function(instance)]
+pub fn read_f32_vec(
+    mut file: Mut<BinaryFile>,
+    order: Ref<str>,
+    count: i64,
+) -> io::Result<Vec<f64>> {
+    BinaryFile::read_f32_vec(&mut file, ByteOrder::parse(&order)?, count)
+}
+
+/// Reads `count` 64-bit floats into a vector in one buffered read.
+#[rune::function(instance)]
+pub fn read_f64_vec(
+    mut file: Mut<BinaryFile>,
+    order: Ref<str>,
+    count: i64,
+) -> io::Result<Vec<f64>> {
+    BinaryFile::read_f64_vec(&mut file, ByteOrder::parse(&order)?, count)
+}
+
+/// Reads `count` unsigned 32-bit integers into a vector in one buffered read.
+#[rune::function(instance)]
+pub fn read_u32_vec(
+    mut file: Mut<BinaryFile>,
+    order: Ref<str>,
+    count: i64,
+) -> io::Result<Vec<i64>> {
+    BinaryFile::read_u32_vec(&mut file, ByteOrder::parse(&order)?, count)
+}
+
+/// Reads `count` signed 32-bit integers into a vector in one buffered read.
+#[rune::function(instance)]
+pub fn read_i32_vec(
+    mut file: Mut<BinaryFile>,
+    order: Ref<str>,
+    count: i64,
+) -> io::Result<Vec<i64>> {
+    BinaryFile::read_i32_vec(&mut file, ByteOrder::parse(&order)?, count)
+}
+
+/// Reads `count` signed 64-bit integers into a vector in one buffered read.
+#[rune::function(instance)]
+pub fn read_i64_vec(
+    mut file: Mut<BinaryFile>,
+    order: Ref<str>,
+    count: i64,
+) -> io::Result<Vec<i64>> {
+    BinaryFile::read_i64_vec(&mut file, ByteOrder::parse(&order)?, count)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    const LE: ByteOrder = ByteOrder::Le;
+    const BE: ByteOrder = ByteOrder::Be;
+
+    fn write_temp(bytes: &[u8]) -> tempfile::NamedTempFile {
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+        file.write_all(bytes).unwrap();
+        file.flush().unwrap();
+        file
+    }
+
+    fn open(file: &tempfile::NamedTempFile) -> BinaryFile {
+        BinaryFile::new(file.path().to_str().unwrap()).unwrap()
+    }
+
+    #[test]
+    fn open_missing_file_names_the_path() {
+        let err = BinaryFile::new("/nonexistent/data.bin").unwrap_err();
+        assert!(err.to_string().contains("/nonexistent/data.bin"));
+    }
+
+    #[test]
+    fn parses_byte_order() {
+        assert!(matches!(ByteOrder::parse("le").unwrap(), ByteOrder::Le));
+        assert!(matches!(ByteOrder::parse("be").unwrap(), ByteOrder::Be));
+        assert!(matches!(ByteOrder::parse("LE").unwrap(), ByteOrder::Le));
+        assert!(matches!(ByteOrder::parse("Be").unwrap(), ByteOrder::Be));
+        let err = ByteOrder::parse("mixed").unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+        assert!(err.to_string().contains("fs::LE"));
+    }
+
+    #[test]
+    fn reads_scalars_in_order() {
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&3_000_000_000u32.to_le_bytes());
+        bytes.extend_from_slice(&(-7i32).to_le_bytes());
+        bytes.extend_from_slice(&(-1234567890123i64).to_le_bytes());
+        bytes.extend_from_slice(&1.5f32.to_le_bytes());
+        bytes.extend_from_slice(&(-2.25f64).to_le_bytes());
+        let tmp = write_temp(&bytes);
+        let mut f = open(&tmp);
+
+        // 3_000_000_000 doesn't fit in i32 - proves the unsigned read widens.
+        assert_eq!(f.read_u32(LE).unwrap(), 3_000_000_000);
+        assert_eq!(f.read_i32(LE).unwrap(), -7);
+        assert_eq!(f.read_i64(LE).unwrap(), -1234567890123);
+        assert_eq!(f.read_f32(LE).unwrap(), 1.5);
+        assert_eq!(f.read_f64(LE).unwrap(), -2.25);
+    }
+
+    #[test]
+    fn reads_scalars_big_endian() {
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&3_000_000_000u32.to_be_bytes());
+        bytes.extend_from_slice(&(-7i32).to_be_bytes());
+        bytes.extend_from_slice(&(-1234567890123i64).to_be_bytes());
+        bytes.extend_from_slice(&1.5f32.to_be_bytes());
+        bytes.extend_from_slice(&(-2.25f64).to_be_bytes());
+        let tmp = write_temp(&bytes);
+        let mut f = open(&tmp);
+
+        assert_eq!(f.read_u32(BE).unwrap(), 3_000_000_000);
+        assert_eq!(f.read_i32(BE).unwrap(), -7);
+        assert_eq!(f.read_i64(BE).unwrap(), -1234567890123);
+        assert_eq!(f.read_f32(BE).unwrap(), 1.5);
+        assert_eq!(f.read_f64(BE).unwrap(), -2.25);
+    }
+
+    #[test]
+    fn bulk_read_past_eof_errors_before_allocating() {
+        let tmp = write_temp(&1.0f32.to_le_bytes());
+        let mut f = open(&tmp);
+        // A corrupt header can request far more data than the file holds; this
+        // must fail as a clean EOF error, not attempt a 4 TB allocation.
+        let err = f.read_f32_vec(LE, 1_000_000_000_000).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::UnexpectedEof);
+        // The file is still usable at its previous position.
+        assert_eq!(f.read_f32(LE).unwrap(), 1.0);
+    }
+
+    #[test]
+    fn reads_bulk_vectors() {
+        let mut bytes = Vec::new();
+        for v in [0.5f32, -1.0, 2.5] {
+            bytes.extend_from_slice(&v.to_le_bytes());
+        }
+        for v in [10i32, -20, 30] {
+            bytes.extend_from_slice(&v.to_le_bytes());
+        }
+        for v in [0.25f64, -3.5] {
+            bytes.extend_from_slice(&v.to_le_bytes());
+        }
+        for v in [-40i64, 50] {
+            bytes.extend_from_slice(&v.to_le_bytes());
+        }
+        let tmp = write_temp(&bytes);
+        let mut f = open(&tmp);
+
+        assert_eq!(f.read_f32_vec(LE, 3).unwrap(), vec![0.5, -1.0, 2.5]);
+        assert_eq!(f.read_i32_vec(LE, 3).unwrap(), vec![10, -20, 30]);
+        f.seek_relative(-3 * 4).unwrap();
+        // The same i32 bytes reread as u32: -20 becomes 2^32 - 20.
+        assert_eq!(f.read_u32_vec(LE, 3).unwrap(), vec![10, 4294967276, 30]);
+        assert_eq!(f.read_f64_vec(LE, 2).unwrap(), vec![0.25, -3.5]);
+        assert_eq!(f.read_i64_vec(LE, 2).unwrap(), vec![-40, 50]);
+        assert_eq!(f.read_f32_vec(LE, 0).unwrap(), Vec::<f64>::new());
+    }
+
+    #[test]
+    fn reads_bulk_vectors_big_endian() {
+        let mut bytes = Vec::new();
+        for v in [0.5f32, -1.0] {
+            bytes.extend_from_slice(&v.to_be_bytes());
+        }
+        for v in [-40i64, 50] {
+            bytes.extend_from_slice(&v.to_be_bytes());
+        }
+        let tmp = write_temp(&bytes);
+        let mut f = open(&tmp);
+
+        assert_eq!(f.read_f32_vec(BE, 2).unwrap(), vec![0.5, -1.0]);
+        assert_eq!(f.read_i64_vec(BE, 2).unwrap(), vec![-40, 50]);
+    }
+
+    #[test]
+    fn seek_and_seek_relative_position_reads() {
+        // A fixed-record layout: 8-byte header (count=3, record_len=2), then
+        // three records of two f32 each - seek straight to record 1.
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&3u32.to_le_bytes());
+        bytes.extend_from_slice(&2u32.to_le_bytes());
+        for v in [0.0f32, 0.1, 1.0, 1.1, 2.0, 2.1] {
+            bytes.extend_from_slice(&v.to_le_bytes());
+        }
+        let tmp = write_temp(&bytes);
+        let mut f = open(&tmp);
+        assert_eq!(f.len(), bytes.len() as i64);
+
+        f.seek(8 + 2 * 4).unwrap();
+        assert_eq!(f.read_f32(LE).unwrap(), 1.0);
+        f.seek_relative(4).unwrap(); // skip the second component of record 1
+        assert_eq!(f.read_f32(LE).unwrap(), 2.0);
+        f.seek_relative(-2 * 4).unwrap(); // back to that skipped component
+        assert_eq!(f.read_f32(LE).unwrap() as f32, 1.1);
+
+        let err = f.seek(-1).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+    }
+
+    #[test]
+    fn seeks_outside_the_file_are_rejected() {
+        let tmp = write_temp(&[0u8; 8]);
+        let mut f = open(&tmp);
+
+        // The end of the file is a valid position; one past it is not.
+        f.seek(8).unwrap();
+        let err = f.seek(9).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+        assert!(err.to_string().contains("file length 8"), "got: {err}");
+
+        f.seek(4).unwrap();
+        let err = f.seek_relative(-5).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+        assert!(err.to_string().contains("-1"), "got: {err}");
+        let err = f.seek_relative(5).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+        // The position is unchanged after a rejected seek.
+        assert_eq!(f.read_i32(LE).unwrap(), 0);
+    }
+
+    #[test]
+    fn byte_order_changes_interpretation() {
+        // One byte pattern, two readings: the orders must actually differ.
+        let tmp = write_temp(&[0x44, 0x33, 0x22, 0x11]);
+        let mut f = open(&tmp);
+        assert_eq!(f.read_u32(LE).unwrap(), 0x11223344);
+        f.seek(0).unwrap();
+        assert_eq!(f.read_u32(BE).unwrap(), 0x44332211);
+    }
+
+    #[test]
+    fn mixed_orders_within_one_file() {
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&7u32.to_le_bytes());
+        bytes.extend_from_slice(&7u32.to_be_bytes());
+        bytes.extend_from_slice(&1.5f32.to_be_bytes());
+        bytes.extend_from_slice(&(-9i64).to_le_bytes());
+        let tmp = write_temp(&bytes);
+        let mut f = open(&tmp);
+
+        assert_eq!(f.read_u32(LE).unwrap(), 7);
+        assert_eq!(f.read_u32(BE).unwrap(), 7);
+        assert_eq!(f.read_f32(BE).unwrap(), 1.5);
+        assert_eq!(f.read_i64(LE).unwrap(), -9);
+    }
+
+    #[test]
+    fn eof_is_an_error() {
+        let tmp = write_temp(&1u32.to_le_bytes());
+        let mut f = open(&tmp);
+        assert_eq!(f.read_u32(LE).unwrap(), 1);
+        let err = f.read_u32(LE).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::UnexpectedEof);
+        let err = f.read_f32_vec(LE, 5).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::UnexpectedEof);
+    }
+
+    #[test]
+    fn negative_count_is_rejected() {
+        let tmp = write_temp(&[]);
+        let mut f = open(&tmp);
+        let err = f.read_f32_vec(LE, -1).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+        assert!(err.to_string().contains("read_f32_vec"));
+    }
+}

--- a/src/scripting/cql/context.rs
+++ b/src/scripting/cql/context.rs
@@ -118,7 +118,8 @@ impl Context {
     /// The user data gets passed through serialization and deserialization to avoid
     /// accidental data sharing.
     pub fn clone(&self) -> Result<Self, LatteError> {
-        let serialized = rmp_serde::to_vec(&self.data)?;
+        let serialized = rmp_serde::to_vec(&self.data)
+            .map_err(|e| LatteError::context_data_encode(&self.data, &e))?;
         let deserialized: Value = rmp_serde::from_slice(&serialized)?;
         Ok(Context {
             session: self.session.clone(),

--- a/src/scripting/cql/context.rs
+++ b/src/scripting/cql/context.rs
@@ -55,6 +55,17 @@ pub struct Context {
     /// Run-level state written through such a copy (report metadata, metric
     /// orientations) is never merged back, so the scripting API rejects those calls.
     pub is_worker_clone: bool,
+    /// True while the script's `prepare_worker` function runs on this context.
+    /// Per-cycle stats written during it (e.g. metrics) are cleared before the
+    /// run starts, so the scripting API rejects those calls.
+    pub in_prepare_worker: bool,
+    /// 0-based index of this worker among `worker_count` workers; 0 on the
+    /// main context used by setup functions.
+    #[rune(get, copy)]
+    pub worker_id: u64,
+    /// Number of worker threads in the run; 1 on the main context.
+    #[rune(get, copy)]
+    pub worker_count: u64,
     #[rune(get)]
     pub data: Value,
 }
@@ -95,6 +106,9 @@ impl Context {
             preferred_datacenter,
             preferred_rack,
             is_worker_clone: false,
+            in_prepare_worker: false,
+            worker_id: 0,
+            worker_count: 1,
             data,
         }
     }
@@ -127,6 +141,9 @@ impl Context {
             preferred_datacenter: self.preferred_datacenter.clone(),
             preferred_rack: self.preferred_rack.clone(),
             is_worker_clone: true,
+            in_prepare_worker: false,
+            worker_id: self.worker_id,
+            worker_count: self.worker_count,
             data: deserialized,
             start_time: TryLock::new(*self.start_time.try_lock().unwrap()),
         })
@@ -152,6 +169,9 @@ impl Context {
             preferred_datacenter: self.preferred_datacenter.clone(),
             preferred_rack: self.preferred_rack.clone(),
             is_worker_clone: self.is_worker_clone,
+            in_prepare_worker: self.in_prepare_worker,
+            worker_id: self.worker_id,
+            worker_count: self.worker_count,
             data: self.data.clone(),
         }
     }

--- a/src/scripting/cql/serialize.rs
+++ b/src/scripting/cql/serialize.rs
@@ -82,30 +82,14 @@ fn serialize_rune_params(
     }
     if let Ok(obj) = value.borrow_ref::<Object>() {
         for col in columns {
-            let cql_val = match obj.get(col.name()) {
-                Some(v) => {
-                    to_scylla_value(v, col.typ()).map_err(|e| SerializationError::new(*e))?
-                }
-                None => Some(CqlValue::Empty),
-            };
-            cql_val
-                .serialize(col.typ(), writer.make_cell_writer())
-                .map_err(SerializationError::new)?;
+            serialize_named_field(obj.get(col.name()), col.typ(), writer)?;
         }
         return Ok(());
     }
     // Handle struct types (rune typed structs)
     if let Ok(rune::runtime::TypeValue::Struct(s)) = value.as_type_value() {
         for col in columns {
-            let cql_val = match s.get(col.name()) {
-                Some(v) => {
-                    to_scylla_value(v, col.typ()).map_err(|e| SerializationError::new(*e))?
-                }
-                None => Some(CqlValue::Empty),
-            };
-            cql_val
-                .serialize(col.typ(), writer.make_cell_writer())
-                .map_err(SerializationError::new)?;
+            serialize_named_field(s.get(col.name()), col.typ(), writer)?;
         }
         return Ok(());
     }
@@ -114,12 +98,55 @@ fn serialize_rune_params(
     )))
 }
 
+/// Serializes one named parameter; a missing key binds as an empty value.
+fn serialize_named_field(
+    v: Option<&Value>,
+    typ: &ColumnType,
+    writer: &mut RowWriter<'_>,
+) -> Result<(), SerializationError> {
+    match v {
+        Some(v) => serialize_rune_cell(v, typ, writer),
+        None => {
+            Some(CqlValue::Empty)
+                .serialize(typ, writer.make_cell_writer())
+                .map_err(SerializationError::new)?;
+            Ok(())
+        }
+    }
+}
+
 /// Serializes a single rune value as a CQL cell.
 fn serialize_rune_cell(
     v: &Value,
     typ: &ColumnType,
     writer: &mut RowWriter<'_>,
 ) -> Result<(), SerializationError> {
+    // A byte string bound to a float vector column is written straight to
+    // the cell (packed little-endian in, wire byte order out), without
+    // materializing per-element values. Nested occurrences (e.g. inside a
+    // list column) take the to_scylla_value path below instead.
+    if let Ok(b) = v.borrow_ref::<rune::runtime::Bytes>() {
+        if let ColumnType::Vector {
+            typ: elem_typ,
+            dimensions,
+            ..
+        } = typ
+        {
+            if matches!(elem_typ.as_ref(), ColumnType::Native(NativeType::Float)) {
+                check_packed_float_len(b.len(), *dimensions as usize, typ)
+                    .map_err(|e| SerializationError::new(*e))?;
+                let mut payload = Vec::with_capacity(b.len());
+                for chunk in b.chunks_exact(4) {
+                    payload.extend_from_slice(&[chunk[3], chunk[2], chunk[1], chunk[0]]);
+                }
+                writer
+                    .make_cell_writer()
+                    .set_value(&payload)
+                    .map_err(SerializationError::new)?;
+                return Ok(());
+            }
+        }
+    }
     let cql_val = to_scylla_value(v, typ).map_err(|e| SerializationError::new(*e))?;
     cql_val
         .serialize(typ, writer.make_cell_writer())
@@ -407,6 +434,33 @@ fn to_scylla_value(v: &Value, typ: &ColumnType) -> Result<Option<CqlValue>, Box<
     if let Ok(b) = v.borrow_ref::<rune::runtime::Bytes>() {
         return match typ {
             ColumnType::Native(NativeType::Blob) => Ok(Some(CqlValue::Blob(b.to_vec()))),
+            // Fallback for byte strings that reach a float vector column
+            // nested inside another value (e.g. an element of a list column):
+            // decodes to per-element values for the driver. Top-level binds
+            // take the direct-to-cell fast path in serialize_rune_cell.
+            ColumnType::Vector {
+                typ: elem_typ,
+                dimensions,
+                ..
+            } => match elem_typ.as_ref() {
+                // Packed little-endian f32, four bytes per element.
+                ColumnType::Native(NativeType::Float) => {
+                    check_packed_float_len(b.len(), *dimensions as usize, typ)?;
+                    let elements = b
+                        .chunks_exact(4)
+                        .map(|c| CqlValue::Float(f32::from_le_bytes(c.try_into().unwrap())))
+                        .collect();
+                    Ok(Some(CqlValue::Vector(elements)))
+                }
+                _ => Err(Box::new(CassError(CassErrorKind::QueryParamConversion(
+                    format!("byte string of {} bytes", b.len()),
+                    format!("{typ:?}"),
+                    Some(format!(
+                        "vector columns with {elem_typ:?} elements do not accept \
+                         packed byte strings"
+                    )),
+                )))),
+            },
             _ => type_mismatch(v, typ),
         };
     }
@@ -591,6 +645,27 @@ fn to_scylla_value(v: &Value, typ: &ColumnType) -> Result<Option<CqlValue>, Box<
     }
 
     type_mismatch(v, typ)
+}
+
+/// Validates that a byte string of `len` bytes exactly fits a float vector
+/// of `dimensions` elements.
+fn check_packed_float_len(
+    len: usize,
+    dimensions: usize,
+    typ: &ColumnType,
+) -> Result<(), Box<CassError>> {
+    let expected = dimensions * 4;
+    if len != expected {
+        return Err(Box::new(CassError(CassErrorKind::QueryParamConversion(
+            format!("byte string of {len} bytes"),
+            format!("{typ:?}"),
+            Some(format!(
+                "a float vector of {dimensions} dimensions needs exactly \
+                 {expected} bytes of packed little-endian f32"
+            )),
+        ))));
+    }
+    Ok(())
 }
 
 fn type_mismatch(v: &Value, typ: &ColumnType) -> Result<Option<CqlValue>, Box<CassError>> {
@@ -1052,6 +1127,62 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_to_scylla_value_vector_from_packed_bytes() {
+        let mut packed = Vec::new();
+        for f in [1.0f32, -2.5, 3.25] {
+            packed.extend_from_slice(&f.to_le_bytes());
+        }
+        let val = rune::to_value(rune::runtime::Bytes::from_slice(&packed).unwrap()).unwrap();
+        let typ = ColumnType::Vector {
+            typ: Box::new(ColumnType::Native(NativeType::Float)),
+            dimensions: 3,
+        };
+        let result = to_scylla_value(&val, &typ).unwrap().unwrap();
+        assert_eq!(
+            result,
+            CqlValue::Vector(vec![
+                CqlValue::Float(1.0),
+                CqlValue::Float(-2.5),
+                CqlValue::Float(3.25),
+            ])
+        );
+    }
+
+    #[test]
+    fn test_to_scylla_value_vector_from_packed_bytes_bad_length() {
+        let val = rune::to_value(rune::runtime::Bytes::from_slice([0u8; 5]).unwrap()).unwrap();
+        let typ = ColumnType::Vector {
+            typ: Box::new(ColumnType::Native(NativeType::Float)),
+            dimensions: 1,
+        };
+        assert!(to_scylla_value(&val, &typ).is_err());
+    }
+
+    #[test]
+    fn test_to_scylla_value_vector_from_packed_bytes_wrong_dimensions() {
+        // Two floats' worth of bytes bound to a 3-dimensional vector: valid f32
+        // packing but the wrong element count - must fail here, not server-side.
+        let val = rune::to_value(rune::runtime::Bytes::from_slice([0u8; 8]).unwrap()).unwrap();
+        let typ = ColumnType::Vector {
+            typ: Box::new(ColumnType::Native(NativeType::Float)),
+            dimensions: 3,
+        };
+        assert!(to_scylla_value(&val, &typ).is_err());
+    }
+
+    #[test]
+    fn test_to_scylla_value_vector_from_packed_bytes_non_float_elements() {
+        // Length would be right for one double, but only float vectors accept
+        // packed byte strings.
+        let val = rune::to_value(rune::runtime::Bytes::from_slice([0u8; 8]).unwrap()).unwrap();
+        let typ = ColumnType::Vector {
+            typ: Box::new(ColumnType::Native(NativeType::Double)),
+            dimensions: 1,
+        };
+        assert!(to_scylla_value(&val, &typ).is_err());
+    }
+
     // ── RuneQueryParams serialize tests ─────────────────────────────
 
     #[test]
@@ -1171,6 +1302,92 @@ mod tests {
         SerializeRow::serialize(&native_vals, &ctx, &mut native_writer).unwrap();
 
         assert_eq!(rune_buf, native_buf);
+    }
+
+    #[test]
+    fn test_serialize_packed_bytes_same_bytes_as_value_vector() {
+        // The fast path (byte string written straight to the cell) must
+        // produce exactly the wire bytes of the per-element value path.
+        let floats = [1.0f32, -2.5, 3.25];
+        let mut packed = Vec::new();
+        for f in floats {
+            packed.extend_from_slice(&f.to_le_bytes());
+        }
+        let packed_val = rune_vec(vec![rune::to_value(
+            rune::runtime::Bytes::from_slice(packed).unwrap(),
+        )
+        .unwrap()]);
+        let value_val = rune_vec(vec![rune_vec(
+            floats
+                .iter()
+                .map(|f| rune::to_value(*f as f64).unwrap())
+                .collect(),
+        )]);
+
+        let cols = [col_spec(
+            "v",
+            ColumnType::Vector {
+                typ: Box::new(ColumnType::Native(NativeType::Float)),
+                dimensions: 3,
+            },
+        )];
+
+        let packed_buf = do_serialize(&RuneQueryParams::new(Some(&packed_val)), &cols);
+        let value_buf = do_serialize(&RuneQueryParams::new(Some(&value_val)), &cols);
+        assert_eq!(packed_buf, value_buf);
+    }
+
+    #[test]
+    fn test_serialize_packed_bytes_named_param_same_bytes_as_value_vector() {
+        // Named parameters must take the same direct-to-cell path as
+        // positional ones and produce identical wire bytes.
+        let floats = [1.0f32, -2.5, 3.25];
+        let mut packed = Vec::new();
+        for f in floats {
+            packed.extend_from_slice(&f.to_le_bytes());
+        }
+        let packed_val = rune_object(vec![(
+            "v",
+            rune::to_value(rune::runtime::Bytes::from_slice(packed).unwrap()).unwrap(),
+        )]);
+        let value_val = rune_object(vec![(
+            "v",
+            rune_vec(
+                floats
+                    .iter()
+                    .map(|f| rune::to_value(*f as f64).unwrap())
+                    .collect(),
+            ),
+        )]);
+
+        let cols = [col_spec(
+            "v",
+            ColumnType::Vector {
+                typ: Box::new(ColumnType::Native(NativeType::Float)),
+                dimensions: 3,
+            },
+        )];
+
+        let packed_buf = do_serialize(&RuneQueryParams::new(Some(&packed_val)), &cols);
+        let value_buf = do_serialize(&RuneQueryParams::new(Some(&value_val)), &cols);
+        assert_eq!(packed_buf, value_buf);
+    }
+
+    #[test]
+    fn test_serialize_packed_bytes_wrong_length_errors() {
+        let packed_val = rune_vec(vec![rune::to_value(
+            rune::runtime::Bytes::from_slice([0u8; 8]).unwrap(),
+        )
+        .unwrap()]);
+        let cols = [col_spec(
+            "v",
+            ColumnType::Vector {
+                typ: Box::new(ColumnType::Native(NativeType::Float)),
+                dimensions: 3,
+            },
+        )];
+        let err = do_serialize_err(&RuneQueryParams::new(Some(&packed_val)), &cols);
+        assert!(err.to_string().contains("12 bytes"), "got: {err}");
     }
 
     #[test]

--- a/src/scripting/functions_common.rs
+++ b/src/scripting/functions_common.rs
@@ -418,6 +418,34 @@ mod test {
     }
 
     #[test]
+    fn clone_error_names_unserializable_data_entries() {
+        #[derive(rune::Any)]
+        struct FileLike;
+
+        let mut original = test_context();
+        let mut obj = rune::runtime::Object::new();
+        obj.insert(
+            rune::alloc::String::try_from("count").unwrap(),
+            rune::runtime::Value::from(7i64),
+        )
+        .unwrap();
+        obj.insert(
+            rune::alloc::String::try_from("file").unwrap(),
+            rune::runtime::Value::new(FileLike).unwrap(),
+        )
+        .unwrap();
+        original.data = rune::runtime::Value::new(obj).unwrap();
+
+        let message = match original.clone() {
+            Err(e) => e.to_string(),
+            Ok(_) => panic!("clone unexpectedly succeeded"),
+        };
+        assert!(message.contains("data.file"), "got: {message}");
+        assert!(!message.contains("data.count"), "got: {message}");
+        assert!(message.contains("plain values"), "got: {message}");
+    }
+
+    #[test]
     fn per_cycle_metrics_rejected_in_prepare_worker() {
         let mut worker = test_context().clone().unwrap();
         assert!(reject_in_setup(&worker, "record_metric").is_ok());

--- a/src/scripting/functions_common.rs
+++ b/src/scripting/functions_common.rs
@@ -334,7 +334,7 @@ fn reject_in_workload(ctx: &Context, function: &str) -> Result<(), VmError> {
         return Err(VmError::panic(format!(
             "{function} is only allowed in single-threaded setup functions \
              such as prepare, schema or erase; called from a workload function \
-             it would have no effect. Use record_metric for per-cycle values."
+             or prepare_worker it would have no effect. Use record_metric for per-cycle values."
         )));
     }
     Ok(())
@@ -344,11 +344,11 @@ fn reject_in_workload(ctx: &Context, function: &str) -> Result<(), VmError> {
 /// run on the original context whose stats are reset before the run, so the
 /// value would be silently dropped. The mirror of `reject_in_workload`.
 fn reject_in_setup(ctx: &Context, function: &str) -> Result<(), VmError> {
-    if !ctx.is_worker_clone {
+    if !ctx.is_worker_clone || ctx.in_prepare_worker {
         return Err(VmError::panic(format!(
             "{function} only takes effect inside workload functions; called from \
-             a setup function such as prepare, schema or erase its value would be \
-             discarded before the run."
+             a setup function such as prepare, prepare_worker, schema or erase its \
+             value would be discarded before the run."
         )));
     }
     Ok(())
@@ -415,6 +415,32 @@ mod test {
             ValidationStrategy::Ignore,
             0,
         )
+    }
+
+    #[test]
+    fn per_cycle_metrics_rejected_in_prepare_worker() {
+        let mut worker = test_context().clone().unwrap();
+        assert!(reject_in_setup(&worker, "record_metric").is_ok());
+
+        // While prepare_worker runs, per-cycle stats would be cleared before
+        // the run starts, so recording them must fail loudly instead.
+        worker.in_prepare_worker = true;
+        assert!(reject_in_setup(&worker, "record_metric").is_err());
+        // The flag must survive the shallow clone handed to the script.
+        assert!(worker.shallow_clone().in_prepare_worker);
+    }
+
+    #[test]
+    fn worker_identity_defaults_and_propagates() {
+        let original = test_context();
+        assert_eq!(original.worker_id, 0);
+        assert_eq!(original.worker_count, 1);
+
+        let mut worker = original.clone().unwrap();
+        worker.worker_id = 3;
+        worker.worker_count = 8;
+        assert_eq!(worker.shallow_clone().worker_id, 3);
+        assert_eq!(worker.shallow_clone().worker_count, 8);
     }
 
     #[test]

--- a/src/scripting/mod.rs
+++ b/src/scripting/mod.rs
@@ -218,6 +218,7 @@ fn init_fs_module() -> Result<Module, ContextError> {
     fs_module.function_meta(binary_file::read_i64_vec)?;
     fs_module.function_meta(binary_file::read_f32_vec)?;
     fs_module.function_meta(binary_file::read_f64_vec)?;
+    fs_module.function_meta(binary_file::read_bytes)?;
 
     Ok(fs_module)
 }

--- a/src/scripting/mod.rs
+++ b/src/scripting/mod.rs
@@ -2,6 +2,7 @@ use rune::{ContextError, Module};
 use rust_embed::RustEmbed;
 use std::collections::HashMap;
 
+mod binary_file;
 pub mod cluster_info;
 mod functions_common;
 pub mod retry_error;
@@ -199,6 +200,24 @@ fn init_fs_module() -> Result<Module, ContextError> {
     fs_module.function_meta(functions_common::read_resource_to_string)?;
     fs_module.function_meta(functions_common::read_resource_lines)?;
     fs_module.function_meta(functions_common::read_resource_words)?;
+
+    fs_module.ty::<binary_file::BinaryFile>()?;
+    fs_module.constant("LE", "le").build()?;
+    fs_module.constant("BE", "be").build()?;
+    fs_module.function_meta(binary_file::open_binary)?;
+    fs_module.function_meta(binary_file::len)?;
+    fs_module.function_meta(binary_file::seek)?;
+    fs_module.function_meta(binary_file::seek_relative)?;
+    fs_module.function_meta(binary_file::read_u32)?;
+    fs_module.function_meta(binary_file::read_i32)?;
+    fs_module.function_meta(binary_file::read_i64)?;
+    fs_module.function_meta(binary_file::read_f32)?;
+    fs_module.function_meta(binary_file::read_f64)?;
+    fs_module.function_meta(binary_file::read_u32_vec)?;
+    fs_module.function_meta(binary_file::read_i32_vec)?;
+    fs_module.function_meta(binary_file::read_i64_vec)?;
+    fs_module.function_meta(binary_file::read_f32_vec)?;
+    fs_module.function_meta(binary_file::read_f64_vec)?;
 
     Ok(fs_module)
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -262,6 +262,39 @@ fn assert_latte_success(result: &CommandResult) {
     );
 }
 
+/// Extracts an integer stat from a summary row such as "Errors [op] 0".
+fn summary_stat(result: &CommandResult, label: &str) -> u64 {
+    result
+        .output
+        .lines()
+        .find_map(|line| {
+            let mut words = line.split_whitespace();
+            if words.next() == Some(label) {
+                words.last().map(str::to_string)
+            } else {
+                None
+            }
+        })
+        .and_then(|v| v.parse().ok())
+        .unwrap_or_else(|| {
+            panic!(
+                "no integer {label} stat in latte output:\n{}",
+                result.output
+            )
+        })
+}
+
+/// A `run` command exits successfully even when workload operations fail, so
+/// checking the exit status is not enough - the error count must be zero.
+fn assert_no_errors(result: &CommandResult) {
+    let errors = summary_stat(result, "Errors");
+    assert_eq!(
+        errors, 0,
+        "latte reported {errors} errors:\n{}",
+        result.output
+    );
+}
+
 fn assert_has_throughput_metrics(result: &CommandResult) {
     assert!(
         result.output.contains("thrpt")
@@ -270,6 +303,117 @@ fn assert_has_throughput_metrics(result: &CommandResult) {
         "Expected throughput metrics in latte output:\n{}",
         result.output
     );
+}
+
+/// Writes a mini binary dataset: header (count, dimension as u32 LE), then
+/// count * dimension little-endian f32 values.
+fn binary_dataset_file(count: u32, dim: u32) -> tempfile::NamedTempFile {
+    let mut data = Vec::with_capacity(8 + (count * dim * 4) as usize);
+    data.extend_from_slice(&count.to_le_bytes());
+    data.extend_from_slice(&dim.to_le_bytes());
+    for i in 0..count * dim {
+        data.extend_from_slice(&(i as f32).to_le_bytes());
+    }
+    let datafile = tempfile::NamedTempFile::new().expect("temp data file");
+    std::fs::write(datafile.path(), &data).expect("write data file");
+    datafile
+}
+
+#[tokio::test]
+#[ignore]
+async fn test_latte_alternator_binary_file_workload() {
+    let db = start_scylla().await.expect("Failed to start ScyllaDB");
+
+    let latte = LatteVariant::Alternator;
+    let workload = workload_path("integration_tests/binary_file_alternator.rn");
+    let duration = "10000";
+
+    let datafile = binary_dataset_file(1000, 4);
+    let datafile_param = format!("datafile=\"{}\"", datafile.path().display());
+
+    println!("\n[TEST-INFO] Phase 1: Create the schema ({:?})", latte);
+    latte.schema(&db, &workload, &["-P", datafile_param.as_str()]);
+
+    println!("\n[TEST-INFO] Phase 2: Insert records read from the binary file");
+    // More than one latte thread, so the per-worker file handle opening runs
+    // on worker-cloned contexts.
+    let insert_result = latte.run(
+        &db,
+        &workload,
+        duration,
+        &["-f=insert", "--threads", "2", "-P", datafile_param.as_str()],
+    );
+    assert_latte_success(&insert_result);
+    assert_no_errors(&insert_result);
+    assert_has_throughput_metrics(&insert_result);
+
+    println!("\n[TEST-INFO] Phase 3: Read the inserted items back");
+    let get_result = latte.run(
+        &db,
+        &workload,
+        duration,
+        &["-f=get", "--threads", "2", "-P", datafile_param.as_str()],
+    );
+    assert_latte_success(&get_result);
+    assert_no_errors(&get_result);
+    assert_eq!(
+        summary_stat(&get_result, "Rows"),
+        summary_stat(&get_result, "Requests"),
+        "some reads found no row:\n{}",
+        get_result.output
+    );
+    assert_has_throughput_metrics(&get_result);
+}
+
+#[tokio::test]
+#[ignore]
+async fn test_latte_cql_binary_file_workload() {
+    let db = start_scylla().await.expect("Failed to start ScyllaDB");
+
+    let latte = LatteVariant::Cql;
+    let workload = workload_path("integration_tests/binary_file.rn");
+    let duration = "10000";
+
+    let datafile = binary_dataset_file(1000, 4);
+    let datafile_param = format!("datafile=\"{}\"", datafile.path().display());
+
+    println!("\n[TEST-INFO] Phase 1: Create the schema ({:?})", latte);
+    let rf_args: &[&str] = match db._container {
+        Some(_) => &["-P", "replication_factor=1"], // Running in a single container
+        None => &[],
+    };
+    let schema_args = [&["-P", datafile_param.as_str()], rf_args].concat();
+    latte.schema(&db, &workload, &schema_args);
+
+    println!("\n[TEST-INFO] Phase 2: Insert records read from the binary file");
+    // More than one latte thread, so the per-worker file handle opening runs
+    // on worker-cloned contexts.
+    let insert_result = latte.run(
+        &db,
+        &workload,
+        duration,
+        &["-f=insert", "--threads", "2", "-P", datafile_param.as_str()],
+    );
+    assert_latte_success(&insert_result);
+    assert_no_errors(&insert_result);
+    assert_has_throughput_metrics(&insert_result);
+
+    println!("\n[TEST-INFO] Phase 3: Read the inserted rows back");
+    let get_result = latte.run(
+        &db,
+        &workload,
+        duration,
+        &["-f=get", "--threads", "2", "-P", datafile_param.as_str()],
+    );
+    assert_latte_success(&get_result);
+    assert_no_errors(&get_result);
+    assert_eq!(
+        summary_stat(&get_result, "Rows"),
+        summary_stat(&get_result, "Requests"),
+        "some reads found no row:\n{}",
+        get_result.output
+    );
+    assert_has_throughput_metrics(&get_result);
 }
 
 #[tokio::test]

--- a/workloads/integration_tests/binary_file.rn
+++ b/workloads/integration_tests/binary_file.rn
@@ -1,0 +1,66 @@
+//! Integration workload for binary file reading: `prepare` reads the file
+//! header, `prepare_worker` opens a per-worker file handle (open files cannot
+//! cross the per-worker clone of `data`), and inserts bind whole records as
+//! packed byte strings to a `vector<float, N>` column.
+//!
+//! Data file layout: header `count: u32 LE, dimension: u32 LE`, then
+//! `count * dimension` little-endian f32 values.
+
+use latte::*;
+
+const KEYSPACE = latte::param!("keyspace", "latte");
+const TABLE = latte::param!("table", "binary_file");
+const REPLICATION_FACTOR = latte::param!("replication_factor", 3);
+const DATAFILE = latte::param!("datafile", "binary_file_data.bin");
+
+const VECTOR_DIM = 4;
+
+const INSERT = "binary_file__insert";
+const GET = "binary_file__get";
+
+pub async fn schema(db) {
+    db.execute(`
+        CREATE KEYSPACE IF NOT EXISTS ${KEYSPACE}
+        WITH replication = {
+          'class'              : 'NetworkTopologyStrategy',
+          'replication_factor' : ${REPLICATION_FACTOR}
+        }
+    `).await?;
+    db.execute(`CREATE TABLE IF NOT EXISTS ${KEYSPACE}.${TABLE} (
+        id bigint PRIMARY KEY,
+        v vector<float, ${VECTOR_DIM}>
+    )`).await?;
+}
+
+pub async fn prepare(db) {
+    let f = fs::open_binary(DATAFILE)?;
+    let count = f.read_u32(fs::LE)?;
+    let dimension = f.read_u32(fs::LE)?;
+    if dimension != VECTOR_DIM {
+        return Err(`${DATAFILE}: expected ${VECTOR_DIM}-element records, header says ${dimension}`);
+    }
+    db.data.count = count;
+    db.prepare(INSERT, `INSERT INTO ${KEYSPACE}.${TABLE} (id, v) VALUES (:id, :v)`).await?;
+    db.prepare(GET, `SELECT id FROM ${KEYSPACE}.${TABLE} WHERE id = :id`).await?;
+}
+
+pub async fn prepare_worker(db) {
+    if db.worker_id >= db.worker_count {
+        return Err(`invalid worker identity: worker ${db.worker_id} of ${db.worker_count}`);
+    }
+    // An open file handle cannot be passed from `prepare`: `data` is
+    // serialized when cloned for each worker thread, so each worker opens
+    // its own handle here.
+    db.data.file = fs::open_binary(DATAFILE)?;
+}
+
+pub async fn insert(db, i) {
+    let idx = i % db.data.count;
+    db.data.file.seek(8 + idx * VECTOR_DIM * 4)?;
+    let record = db.data.file.read_bytes(VECTOR_DIM * 4)?;
+    db.execute_prepared(INSERT, #{ "id": idx, "v": record }).await?
+}
+
+pub async fn get(db, i) {
+    db.execute_prepared(GET, #{ "id": i % db.data.count }).await?
+}

--- a/workloads/integration_tests/binary_file_alternator.rn
+++ b/workloads/integration_tests/binary_file_alternator.rn
@@ -1,0 +1,48 @@
+//! Alternator twin of `binary_file.rn`: the same binary dataset, with records
+//! stored as DynamoDB binary attribute values instead of a CQL vector column.
+//!
+//! Data file layout: header `count: u32 LE, dimension: u32 LE`, then
+//! `count * dimension` little-endian f32 values.
+
+use latte::*;
+
+const TABLE = latte::param!("table", "binary_file");
+const DATAFILE = latte::param!("datafile", "binary_file_data.bin");
+
+const VECTOR_DIM = 4;
+
+pub async fn schema(db) {
+    db.create_table(TABLE, "pk").await?;
+}
+
+pub async fn prepare(db) {
+    let f = fs::open_binary(DATAFILE)?;
+    let count = f.read_u32(fs::LE)?;
+    let dimension = f.read_u32(fs::LE)?;
+    if dimension != VECTOR_DIM {
+        return Err(`${DATAFILE}: expected ${VECTOR_DIM}-element records, header says ${dimension}`);
+    }
+    db.data.count = count;
+}
+
+pub async fn prepare_worker(db) {
+    if db.worker_id >= db.worker_count {
+        return Err(`invalid worker identity: worker ${db.worker_id} of ${db.worker_count}`);
+    }
+    // An open file handle cannot be passed from `prepare`: `data` is
+    // serialized when cloned for each worker thread, so each worker opens
+    // its own handle here.
+    db.data.file = fs::open_binary(DATAFILE)?;
+}
+
+pub async fn insert(db, i) {
+    let idx = i % db.data.count;
+    db.data.file.seek(8 + idx * VECTOR_DIM * 4)?;
+    let record = db.data.file.read_bytes(VECTOR_DIM * 4)?;
+    db.put(TABLE, #{ pk: `${idx}`, v: record }, ()).await?
+}
+
+pub async fn get(db, i) {
+    let idx = i % db.data.count;
+    db.get(TABLE, #{ pk: `${idx}` }, #{ consistent_read: true }).await?
+}


### PR DESCRIPTION
Rune workload scripts can read data files only as text. Standard vector dataset formats such as big-ann-benchmarks fbin/ibin are binary. Using them today means converting to text first - larger on disk, slower to load. This PR adds native binary reading.

This PR adds native binary reading:
- `fs::open_binary(path)` - buffered, positioned, typed little endian reads
- byte strings of packed little endian f32 bind directly to `vector<float, N>` parameters - float datasets can be held and bound as raw bytes end to end (~4x less memory, ~4x faster load, ~2.9x insert throughput on a 50k x 1536 dim dataset).
- available in alternator workloads too (the `fs` module is shared); integration tests cover both CQL and alternator, each at 2 threads

Memory optimization is separate from the data streaming, which will come in a follow up PR.

Fixes QATOOLS-315