### PR TITLE
retry_error: fix retry backoff overflow at attempt numbers >= 64

### DIFF
--- a/src/scripting/retry_error.rs
+++ b/src/scripting/retry_error.rs
@@ -13,7 +13,7 @@ pub fn get_exponential_retry_interval(
 ) -> Duration {
     let min_interval_float: f64 = min_interval.as_secs_f64();
     let mut current_interval: f64 =
-        min_interval_float * (2u64.pow(current_attempt_num.try_into().unwrap_or(0)) as f64);
+        min_interval_float * ((1u64 << current_attempt_num.min(63)) as f64);
 
     // Add jitter
     current_interval += random::<f64>() * min_interval_float;

--- a/src/scripting/retry_error.rs
+++ b/src/scripting/retry_error.rs
@@ -50,3 +50,33 @@ pub async fn handle_retry_error(ctxt: &Context, current_attempt_num: u64, curren
         eprintln!("{err_msg}");
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn interval_grows_with_attempts_and_is_capped_by_max() {
+        let min = Duration::from_millis(100);
+        let max = Duration::from_secs(5);
+        let first = get_exponential_retry_interval(min, max, 1);
+        assert!(first >= Duration::from_millis(150) && first < Duration::from_millis(250));
+        assert!(get_exponential_retry_interval(min, max, 10) <= max);
+    }
+
+    #[test]
+    fn large_attempt_numbers_do_not_overflow() {
+        let min = Duration::from_millis(100);
+        let max = Duration::from_secs(5);
+        // Attempt 64 used to wrap the power to 0, making the jittered interval
+        // negative and panicking Duration::from_secs_f64.
+        for attempt in [63, 64, 65, 1_000, u64::MAX] {
+            let interval = get_exponential_retry_interval(min, max, attempt);
+            assert!(interval <= max, "attempt {attempt}: {interval:?} > max");
+            assert!(
+                interval >= max - min / 2,
+                "attempt {attempt}: {interval:?} lost the exponential cap"
+            );
+        }
+    }
+}


### PR DESCRIPTION
`get_exponential_retry_interval` computes retry interval as exponentially increasing current interval, clamped by max interval value.
```rust
    current_interval = min_interval * multiplier
    result = current_interval.min(max_interval)
```
which is:
```rust
    current_interval = min_interval * 2^(current_attempt)
    result = current_interval.min(max_interval)
```
This means that with low max_interval value we can quickly reach current_attempt value of 64, and trigger overflow:
```rust
    current_interval = min_interval * 2^64 = min_interval * 0 = 0
```
On debug builds `u64::pow` panics, but on release builds it silently wraps it to 0, making `current_interval` = 1.

This is a bug. Jitter exposes it. Effectively jitter calculation gives `[-min_interval/2, min_interval/2)` value range. This is ok as long as base duration current_interval is >= min_interval. Overflow breaks it. If random jitter is < 0, then `current_interval` is < 0. This causes `Duration::from_secs_f64` to panic.

Any run relying on more than 63 retries, like a workload waiting for an index build by retrying a probe query, dies after ~5.4 minutes of default backoff instead of continuing to wait.

Clamp the exponent to 63. The interval is already capped at the configured maximum afterwards, so larger exponents cannot change the result.

Fixes: QATOOLS-401